### PR TITLE
feat: 只生成 os-checker 配置文件指定的 packages 的信息和测例

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -44,32 +44,35 @@ jobs:
           chmod +x ~/.cargo/bin/os-checker
           os-checker layout --help
 
-      - name: Install plugin-cargo
-        run: cargo install --path .
+      - name: Test os-checker
+        run: cargo test -- test_sel4
 
-      - name: Run plugin-cargo
-        run: |
-          os-checker-plugin-cargo # os-checker.json
-          tree --gitignore -h tmp
-
-      - name: Push to database
-        env:
-          PLUGIN_PATH: plugin/cargo
-        run: |
-          git config --global user.name "zjp-CN[bot]"
-          git config --global user.email "zjp-CN[bot]@users.noreply.github.com"
-
-          echo "正在 clone os-checker/database"
-          git clone https://x-access-token:${{ env.ACCESS_TOKEN }}@github.com/os-checker/database.git
-          echo "成功 clone os-checker/database"
-
-          cd database
-          git switch ${{ env.DATABASE }}
-
-          rm -rf ${{ env.PLUGIN_PATH }}
-          mkdir -p ${{ env.PLUGIN_PATH }}
-          mv ../tmp ${{ env.PLUGIN_PATH }}/info
-          cp ../push.sh ${{ env.PLUGIN_PATH }}
-
-          bash ${{ env.PLUGIN_PATH }}/push.sh
+      # - name: Install plugin-cargo
+      #   run: cargo install --path .
+      #
+      # - name: Run plugin-cargo
+      #   run: |
+      #     os-checker-plugin-cargo # os-checker.json
+      #     tree --gitignore -h tmp
+      #
+      # - name: Push to database
+      #   env:
+      #     PLUGIN_PATH: plugin/cargo
+      #   run: |
+      #     git config --global user.name "zjp-CN[bot]"
+      #     git config --global user.email "zjp-CN[bot]@users.noreply.github.com"
+      #
+      #     echo "正在 clone os-checker/database"
+      #     git clone https://x-access-token:${{ env.ACCESS_TOKEN }}@github.com/os-checker/database.git
+      #     echo "成功 clone os-checker/database"
+      #
+      #     cd database
+      #     git switch ${{ env.DATABASE }}
+      #
+      #     rm -rf ${{ env.PLUGIN_PATH }}
+      #     mkdir -p ${{ env.PLUGIN_PATH }}
+      #     mv ../tmp ${{ env.PLUGIN_PATH }}/info
+      #     cp ../push.sh ${{ env.PLUGIN_PATH }}
+      #
+      #     bash ${{ env.PLUGIN_PATH }}/push.sh
 

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Test os-checker
         env:
           CONFIGS: "repos-default.json repos-ui.json"
-        run: cargo test -- test_sel4 --nocapture && ls -alh /tmp/os-checker-plugin-cargo
+        run: cargo test -- test_sel4 --nocapture && tree -L 2 /tmp/os-checker-plugin-cargo
 
       # - name: Install plugin-cargo
       #   run: cargo install --path .

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -50,7 +50,7 @@ jobs:
           os-checker layout --help
 
       - name: Test os-checker layout --list-targets
-        run: cargo test -- test_sel4 --nocapture && tree -L 2 /tmp/os-checker-plugin-cargo
+        run: cargo test -- test_sel4 --nocapture
 
       - name: Test pkg_targets
         run: cargo test -- test_pkg_targets --nocapture

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Test os-checker
         env:
           CONFIGS: "repos-default.json repos-ui.json"
-        run: cargo test -- test_sel4
+        run: cargo test -- test_sel4 --nocapture
 
       # - name: Install plugin-cargo
       #   run: cargo install --path .

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -43,7 +43,6 @@ jobs:
 
       - name: Install os-checker
         run: |
-          wget https://github.com/os-checker/database/releases/download/cache-v8.redb/repos-default.json
           wget https://raw.githubusercontent.com/os-checker/os-checker/refs/heads/main/assets/repos-ui.json
           gh release download -R os-checker/database ${{ env.TAG_CACHE }} -p os-checker -D ~/.cargo/bin/
           chmod +x ~/.cargo/bin/os-checker

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -49,38 +49,38 @@ jobs:
           chmod +x ~/.cargo/bin/os-checker
           os-checker layout --help
 
-      - name: Test os-checker layout --list-targets
-        run: cargo test -- test_sel4 --nocapture
+      # - name: Test os-checker layout --list-targets
+      #   run: cargo test -- test_sel4 --nocapture
+      #
+      # - name: Test pkg_targets
+      #   run: cargo test -- test_pkg_targets --nocapture
 
-      - name: Test pkg_targets
-        run: cargo test -- test_pkg_targets --nocapture
+      - name: Install plugin-cargo
+        run: cargo install --path .
 
-      # - name: Install plugin-cargo
-      #   run: cargo install --path .
-      #
-      # - name: Run plugin-cargo
-      #   run: |
-      #     os-checker-plugin-cargo # os-checker.json
-      #     tree --gitignore -h tmp
-      #
-      # - name: Push to database
-      #   env:
-      #     PLUGIN_PATH: plugin/cargo
-      #   run: |
-      #     git config --global user.name "zjp-CN[bot]"
-      #     git config --global user.email "zjp-CN[bot]@users.noreply.github.com"
-      #
-      #     echo "正在 clone os-checker/database"
-      #     git clone https://x-access-token:${{ env.ACCESS_TOKEN }}@github.com/os-checker/database.git
-      #     echo "成功 clone os-checker/database"
-      #
-      #     cd database
-      #     git switch ${{ env.DATABASE }}
-      #
-      #     rm -rf ${{ env.PLUGIN_PATH }}
-      #     mkdir -p ${{ env.PLUGIN_PATH }}
-      #     mv ../tmp ${{ env.PLUGIN_PATH }}/info
-      #     cp ../push.sh ${{ env.PLUGIN_PATH }}
-      #
-      #     bash ${{ env.PLUGIN_PATH }}/push.sh
+      - name: Run plugin-cargo
+        run: |
+          os-checker-plugin-cargo # os-checker.json
+          tree --gitignore -h tmp
+
+      - name: Push to database
+        env:
+          PLUGIN_PATH: plugin/cargo
+        run: |
+          git config --global user.name "zjp-CN[bot]"
+          git config --global user.email "zjp-CN[bot]@users.noreply.github.com"
+
+          echo "正在 clone os-checker/database"
+          git clone https://x-access-token:${{ env.ACCESS_TOKEN }}@github.com/os-checker/database.git
+          echo "成功 clone os-checker/database"
+
+          cd database
+          git switch ${{ env.DATABASE }}
+
+          rm -rf ${{ env.PLUGIN_PATH }}
+          mkdir -p ${{ env.PLUGIN_PATH }}
+          mv ../tmp ${{ env.PLUGIN_PATH }}/info
+          cp ../push.sh ${{ env.PLUGIN_PATH }}
+
+          bash ${{ env.PLUGIN_PATH }}/push.sh
 

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -24,6 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt, clippy
 
       - name: Generate list.json
         run: |

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -14,7 +14,10 @@ env:
   # database branch
   DATABASE: main
   BOT: 1
+  # repos-default.json tag in database release
   TAG_REPOS_DEFAULT: cache-v8.redb
+  # cache.redb tag in database release
+  TAG_CACHE: cache-v11.redb
 
 jobs:
   run:
@@ -34,6 +37,12 @@ jobs:
           wget https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-0.9.81/cargo-nextest-0.9.81-x86_64-unknown-linux-gnu.tar.gz
           tar xzvf cargo-nextest-0.9.81-x86_64-unknown-linux-gnu.tar.gz
           mv cargo-nextest ~/.cargo/bin
+
+      - name: Install os-checker
+        run: |
+          gh release download -R os-checker/database ${{ env.TAG_CACHE }} -p os-checker -D ~/.cargo/bin/
+          chmod +x ~/.cargo/bin/os-checker
+          os-checker layout --help
 
       - name: Install plugin-cargo
         run: cargo install --path .

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -18,6 +18,7 @@ env:
   TAG_REPOS_DEFAULT: cache-v8.redb
   # cache.redb tag in database release
   TAG_CACHE: cache-v11.redb
+  CONFIGS: "repos-default.json repos-ui.json"
 
 jobs:
   run:
@@ -48,10 +49,11 @@ jobs:
           chmod +x ~/.cargo/bin/os-checker
           os-checker layout --help
 
-      - name: Test os-checker
-        env:
-          CONFIGS: "repos-default.json repos-ui.json"
+      - name: Test os-checker layout --list-targets
         run: cargo test -- test_sel4 --nocapture && tree -L 2 /tmp/os-checker-plugin-cargo
+
+      - name: Test pkg_targets
+        run: cargo test -- test_pkg_targets --nocapture
 
       # - name: Install plugin-cargo
       #   run: cargo install --path .

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -40,11 +40,15 @@ jobs:
 
       - name: Install os-checker
         run: |
+          wget https://github.com/os-checker/database/releases/download/cache-v8.redb/repos-default.json
+          wget https://raw.githubusercontent.com/os-checker/os-checker/refs/heads/main/assets/repos-ui.json
           gh release download -R os-checker/database ${{ env.TAG_CACHE }} -p os-checker -D ~/.cargo/bin/
           chmod +x ~/.cargo/bin/os-checker
           os-checker layout --help
 
       - name: Test os-checker
+        env:
+          CONFIGS: "repos-default.json repos-ui.json"
         run: cargo test -- test_sel4
 
       # - name: Install plugin-cargo

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Run plugin-cargo
         run: |
-          os-checker-plugin-cargo # os-checker.json
+          os-checker-plugin-cargo os-checker.json
           tree --gitignore -h tmp
 
       - name: Push to database

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Run plugin-cargo
         run: |
-          os-checker-plugin-cargo os-checker.json
+          os-checker-plugin-cargo #os-checker.json
           tree --gitignore -h tmp
 
       - name: Push to database

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Test os-checker
         env:
           CONFIGS: "repos-default.json repos-ui.json"
-        run: cargo test -- test_sel4 --nocapture
+        run: cargo test -- test_sel4 --nocapture && ls -alh /tmp/os-checker-plugin-cargo
 
       # - name: Install plugin-cargo
       #   run: cargo install --path .

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "castaway"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,6 +150,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6050c3a16ddab2e412160b31f2c871015704239bca62f72f6e5f0be631d3f644"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "serde",
+ "static_assertions",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "duct"
 version = "0.13.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,6 +199,19 @@ checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
 dependencies = [
  "indenter",
  "once_cell",
+]
+
+[[package]]
+name = "generator"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb949699c3e4df3a183b1d2142cb24277057055ed23c68ed58894f76c517223"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows",
 ]
 
 [[package]]
@@ -228,6 +274,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,6 +308,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "musli"
+version = "0.0.124"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b310b280353d9e1c92861820321f8742b02666acaf984a29cd8946965444384"
+dependencies = [
+ "loom",
+ "musli-core",
+ "serde",
+ "simdutf8",
+]
+
+[[package]]
+name = "musli-core"
+version = "0.0.124"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d00e227a374e92550ce2eb5002ae116e02a43926d7243c95997138406ae4e157"
+dependencies = [
+ "musli-macros",
+]
+
+[[package]]
+name = "musli-macros"
+version = "0.0.124"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7427c9aa85c882cd4dbe712d2fcdc511db05d595f7787e6747c90cd7d67efc4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -282,6 +373,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "object"
 version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -307,12 +404,32 @@ dependencies = [
  "eyre",
  "indexmap",
  "nextest-metadata",
+ "os-checker-types",
  "serde",
  "serde_json",
  "tracing",
  "tracing-error",
  "tracing-subscriber",
  "walkdir",
+]
+
+[[package]]
+name = "os-checker-types"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3acb76bf0442078c9f1911da1b4bfe7207ee240b7dde1e342151cac15ff01cd"
+dependencies = [
+ "camino",
+ "cargo_metadata",
+ "compact_str",
+ "eyre",
+ "indexmap",
+ "musli",
+ "redb",
+ "serde",
+ "serde_json",
+ "time",
+ "tracing",
 ]
 
 [[package]]
@@ -344,6 +461,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -359,6 +482,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "redb"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84b1de48a7cf7ba193e81e078d17ee2b786236eed1d3f7c60f8a09545efc4925"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -412,6 +544,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustversion"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -425,6 +563,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "semver"
@@ -494,6 +638,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -508,6 +658,12 @@ dependencies = [
  "borsh",
  "serde",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
@@ -568,6 +724,36 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "time"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -693,6 +879,70 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-strings",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,6 +400,7 @@ dependencies = [
  "camino",
  "cargo_metadata",
  "color-eyre",
+ "compact_str",
  "duct",
  "eyre",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2021"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 
+os-checker-types = "0.4.1"
+
 cargo_metadata  = "0.18"
 duct = "0.13"
 walkdir = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 
+compact_str = "0.8"
 os-checker-types = "0.4.1"
 
 cargo_metadata  = "0.18"

--- a/os-checker.json
+++ b/os-checker.json
@@ -1,4 +1,3 @@
 [
-  "os-checker/os-checker",
-  "os-checker/os-checker-test-suite"
+  "qclic/fdt-parser"
 ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod prelude {
     pub use camino::{Utf8Path, Utf8PathBuf};
     pub use cargo_metadata::Metadata;
+    pub use compact_str::CompactString as XString;
     pub use eyre::{Context, Result};
     pub use indexmap::IndexMap;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ fn main() -> Result<()> {
 
     for user_repo in &list {
         let _span = error_span!("list", user_repo).entered();
-        match repo::Repo::new(user_repo, repo::RepoSource::Github) {
+        match repo::Repo::new(user_repo) {
             Ok(repo) => {
                 match repo.output() {
                     Ok(output) => outputs.push(output),

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -22,6 +22,7 @@ pub struct Repo {
 
 impl Repo {
     pub fn new(user_repo: &str) -> Result<Repo> {
+        let _span = error_span!("Repo::new", user_repo).entered();
         let mut split = user_repo.split("/");
         let user = split
             .next()
@@ -38,11 +39,13 @@ impl Repo {
 
         let workspaces = workspaces(&cargo_tomls)?;
 
+        let pkg_targets = os_checker::run(user_repo)?;
+        info!(?pkg_targets);
         Ok(Repo {
             user,
             repo,
             dir,
-            pkg_targets: os_checker::run(user_repo)?,
+            pkg_targets,
             cargo_tomls,
             workspaces,
         })

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -32,6 +32,9 @@ impl Repo {
             .with_context(|| format!("Not found repo in `{user_repo}`."))?
             .to_owned();
 
+        // this implies repo downloading
+        let pkg_targets = os_checker::run(user_repo)?;
+
         let dir = local_repo_dir(&user, &repo);
         let mut cargo_tomls = get_cargo_tomls_recursively(&dir);
         cargo_tomls.sort_unstable();
@@ -39,7 +42,6 @@ impl Repo {
 
         let workspaces = workspaces(&cargo_tomls)?;
 
-        let pkg_targets = os_checker::run(user_repo)?;
         info!(?pkg_targets);
         Ok(Repo {
             user,

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -22,7 +22,6 @@ pub struct Repo {
 
 impl Repo {
     pub fn new(user_repo: &str) -> Result<Repo> {
-        let _span = error_span!("Repo::new", user_repo).entered();
         let mut split = user_repo.split("/");
         let user = split
             .next()
@@ -75,6 +74,7 @@ impl Repo {
             .inspect_err(|err| error!(?err, "Failed to get testcases"))
             .unwrap_or_default();
         let pkgs = self.packages();
+        info!(pkgs = ?pkgs.iter().map(|p| &p.name).collect::<Vec<_>>());
 
         let mut outputs = IndexMap::with_capacity(pkgs.len());
         for pkg in pkgs {

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -6,6 +6,7 @@ use testcases::PkgTests;
 
 mod output;
 mod testcases;
+mod os_checker;
 
 pub enum RepoSource {
     Github,

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -160,3 +160,9 @@ fn workspaces(cargo_tomls: &[Utf8PathBuf]) -> Result<Workspaces> {
 fn test_cargo_tomls() {
     dbg!(get_cargo_tomls_recursively(Utf8Path::new(".")));
 }
+
+#[test]
+fn test_pkg_targets() -> Result<()> {
+    dbg!(Repo::new("seL4/rust-sel4")?.pkg_targets);
+    Ok(())
+}

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -38,11 +38,9 @@ impl Repo {
         let dir = local_repo_dir(&user, &repo);
         let mut cargo_tomls = get_cargo_tomls_recursively(&dir);
         cargo_tomls.sort_unstable();
-        info!(?cargo_tomls);
 
         let workspaces = workspaces(&cargo_tomls)?;
 
-        info!(?pkg_targets);
         Ok(Repo {
             user,
             repo,
@@ -59,10 +57,7 @@ impl Repo {
             .values()
             .flat_map(|ws| ws.workspace_packages())
             // but don't emit packages that are not checked by os-checker
-            .filter(|pkg| {
-                info!(pkg.name);
-                self.pkg_targets.contains_key(pkg.name.as_str())
-            })
+            .filter(|pkg| self.pkg_targets.contains_key(pkg.name.as_str()))
             .collect()
     }
 
@@ -82,7 +77,6 @@ impl Repo {
             .inspect_err(|err| error!(?err, "Failed to get testcases"))
             .unwrap_or_default();
         let pkgs = self.packages();
-        info!(pkgs = ?pkgs.iter().map(|p| &p.name).collect::<Vec<_>>());
 
         let mut outputs = IndexMap::with_capacity(pkgs.len());
         for pkg in pkgs {

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -48,11 +48,13 @@ impl Repo {
         })
     }
 
-    // packages in all repos
+    // packages in all workspaces
     fn packages(&self) -> Vec<&Package> {
         self.workspaces
             .values()
             .flat_map(|ws| ws.workspace_packages())
+            // but don't emit packages that are not checked by os-checker
+            .filter(|pkg| self.pkg_targets.contains_key(pkg.name.as_str()))
             .collect()
     }
 

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -69,6 +69,8 @@ impl Repo {
     fn get_pkg_tests(&self) -> Result<PkgTests> {
         let mut map = PkgTests::new();
         for workspace_root in self.workspaces.keys() {
+            // NOTE: nextest is run under all packages in a workspace,
+            // maybe we should run tests for each package?
             map.extend(testcases::get(&self.dir, workspace_root)?);
         }
         Ok(map)

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -105,7 +105,7 @@ impl Repo {
     }
 }
 
-pub fn git_clone_dir() -> &'static Utf8Path {
+pub fn local_base_dir() -> &'static Utf8Path {
     static GIT_CLONE_DIR: LazyLock<Utf8PathBuf> =
         LazyLock::new(|| Utf8PathBuf::from_iter(["/tmp", "os-checker-plugin-cargo"]));
 
@@ -114,7 +114,7 @@ pub fn git_clone_dir() -> &'static Utf8Path {
 
 // dependes on where does os-checker put the repo
 pub fn local_repo_dir(user: &str, repo: &str) -> Utf8PathBuf {
-    let mut dir = git_clone_dir().to_owned();
+    let mut dir = local_base_dir().to_owned();
     dir.extend([user, repo]);
     dir
 }
@@ -163,6 +163,8 @@ fn test_cargo_tomls() {
 
 #[test]
 fn test_pkg_targets() -> Result<()> {
-    dbg!(Repo::new("seL4/rust-sel4")?.pkg_targets);
+    let repo = Repo::new("seL4/rust-sel4")?;
+    dbg!(&repo.pkg_targets);
+    repo.remove_local_dir()?;
     Ok(())
 }

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -35,6 +35,7 @@ impl Repo {
         let dir = local_repo_dir(&user, &repo);
         let mut cargo_tomls = get_cargo_tomls_recursively(&dir);
         cargo_tomls.sort_unstable();
+        info!(?cargo_tomls);
 
         let workspaces = workspaces(&cargo_tomls)?;
 

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -56,7 +56,10 @@ impl Repo {
             .values()
             .flat_map(|ws| ws.workspace_packages())
             // but don't emit packages that are not checked by os-checker
-            .filter(|pkg| self.pkg_targets.contains_key(pkg.name.as_str()))
+            .filter(|pkg| {
+                info!(pkg.name);
+                self.pkg_targets.contains_key(pkg.name.as_str())
+            })
             .collect()
     }
 

--- a/src/repo/os_checker.rs
+++ b/src/repo/os_checker.rs
@@ -1,3 +1,4 @@
+use super::local_base_dir;
 use crate::prelude::*;
 use duct::cmd;
 use os_checker_types::layout::ListTargets;
@@ -9,7 +10,7 @@ pub fn run(user_repo: &str) -> Result<PkgTargets> {
     let configs =
         std::env::var("CONFIGS").with_context(|| "Must specify `CONFIGS` environment variable.")?;
 
-    let dir = super::git_clone_dir();
+    let dir = local_base_dir();
     let mut args = vec![
         "layout",
         "--base-dir",
@@ -49,6 +50,6 @@ fn list_to_map(v: Vec<ListTargets>) -> PkgTargets {
 fn test_sel4() -> Result<()> {
     let repo = "seL4/rust-sel4";
     dbg!(run(repo)?);
-    // TODO: remove dir
+    std::fs::remove_dir_all(local_base_dir())?;
     Ok(())
 }

--- a/src/repo/os_checker.rs
+++ b/src/repo/os_checker.rs
@@ -1,0 +1,33 @@
+use crate::prelude::*;
+use duct::cmd;
+use os_checker_types::layout::ListTargets;
+
+pub fn run(repo: &str) -> Result<Vec<ListTargets>> {
+    let dir = super::git_clone_dir();
+    let output = cmd!(
+        "os-checker",
+        "layout",
+        "--base-dir",
+        dir,
+        "--list-targets",
+        repo
+    )
+    .stdout_capture()
+    .stderr_capture()
+    .run()?;
+
+    ensure!(
+        output.status.success(),
+        "{}",
+        std::str::from_utf8(&output.stderr)?
+    );
+
+    Ok(serde_json::from_reader(output.stdout.as_slice())?)
+}
+
+#[test]
+fn test_sel4() -> Result<()> {
+    let repo = "seL4/rust-sel4";
+    dbg!(run(repo)?);
+    Ok(())
+}

--- a/src/repo/os_checker.rs
+++ b/src/repo/os_checker.rs
@@ -14,6 +14,7 @@ pub fn run(repo: &str) -> Result<Vec<ListTargets>> {
     )
     .stdout_capture()
     .stderr_capture()
+    .unchecked()
     .run()?;
 
     ensure!(

--- a/src/repo/os_checker.rs
+++ b/src/repo/os_checker.rs
@@ -2,13 +2,21 @@ use crate::prelude::*;
 use duct::cmd;
 use os_checker_types::layout::ListTargets;
 
-pub fn run(repo: &str) -> Result<Vec<ListTargets>> {
+pub type PkgTargets = IndexMap<XString, Vec<String>>;
+
+pub fn run(user_repo: &str) -> Result<PkgTargets> {
     // multiple config paths are separated by ` `
     let configs =
         std::env::var("CONFIGS").with_context(|| "Must specify `CONFIGS` environment variable.")?;
 
     let dir = super::git_clone_dir();
-    let mut args = vec!["layout", "--base-dir", dir.as_str(), "--list-targets", repo];
+    let mut args = vec![
+        "layout",
+        "--base-dir",
+        dir.as_str(),
+        "--list-targets",
+        user_repo,
+    ];
 
     for config in configs.split(" ").map(|s| s.trim()) {
         if !config.is_empty() {
@@ -28,12 +36,19 @@ pub fn run(repo: &str) -> Result<Vec<ListTargets>> {
         std::str::from_utf8(&output.stderr)?
     );
 
-    Ok(serde_json::from_reader(output.stdout.as_slice())?)
+    let v: Vec<ListTargets> = serde_json::from_reader(output.stdout.as_slice())?;
+    Ok(list_to_map(v))
+}
+
+/// returns `Map<PkgName, TargetTriples>`
+fn list_to_map(v: Vec<ListTargets>) -> PkgTargets {
+    v.into_iter().map(|l| (l.pkg, l.targets)).collect()
 }
 
 #[test]
 fn test_sel4() -> Result<()> {
     let repo = "seL4/rust-sel4";
     dbg!(run(repo)?);
+    // TODO: remove dir
     Ok(())
 }


### PR DESCRIPTION
该 PR 前，info 页面有许多用作示例的 packages，


例如 embassy 有 94 个 packages，其中 43 个带 `-examples` 结尾的 packages，它们不适合展示到 info 页面：

![截图_20241117194810](https://github.com/user-attachments/assets/8d1f5b6f-877f-4f13-af34-ca555fa005ef)
![截图_20241117200401](https://github.com/user-attachments/assets/0d661a0c-cf9b-44a3-a544-affd5bfb765d)

该 PR 后，info 页面会减少这些不被检查的 packages —— 这基于目前的一个假设前提，os-checker 配置文件指定的 packages 是 info 页面展示的。

embassy 的 info 页面只显示 33 个 packages，不再包含 `-examples` 结尾的 packages：
![截图_20241117213745](https://github.com/user-attachments/assets/4ab94041-807e-4719-bc13-ab02da46a05e)


然而这个前提可能发生变化，因为 os-checker 将来也可能检查这些 packages（目前排除它们是因为检查它们需要更多的时间和空间，这在 Github Runner 上可能很难完成）。因此，将来需要在配置文件中增加字段来划定该仓库有哪些功能库，来专门用于 info 页面。