### PR TITLE
feat: 初步支持 Miri

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -23,7 +23,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
         with:
-          components: rustfmt, clippy
+          components: rustfmt, clippy, miri
+
+      - name: Set up miri
+        run: cargo miri setup
 
       - name: Fetch os-checker config JSONs
         run: |

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -13,8 +13,8 @@ env:
   DATABASE: debug
   BOT: 1
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
-  OS_CHECKER_CONFIGS: repos.json
-  # OS_CHECKER_CONFIGS: repos-default.json repos-ui.json
+  # OS_CHECKER_CONFIGS: repos.json
+  OS_CHECKER_CONFIGS: repos-default.json repos-ui.json
 
 jobs:
   run:
@@ -30,13 +30,13 @@ jobs:
 
       - name: Fetch os-checker config JSONs
         run: |
-          # gh release download -R kern-crates/.github -p os-checker_config.json
-          # # temporarily disable qclic/e1000e-frame
-          # jq 'del(."qclic/e1000e-frame")' os-checker_config.json > repos-default.json
-          # wget https://raw.githubusercontent.com/os-checker/os-checker/refs/heads/main/assets/repos-ui.json
-          # echo '{"os-checker/os-checker":{}}' > repos.json
+          gh release download -R kern-crates/.github -p os-checker_config.json
+          # temporarily disable qclic/e1000e-frame
+          jq 'del(."qclic/e1000e-frame")' os-checker_config.json > repos-default.json
+          wget https://raw.githubusercontent.com/os-checker/os-checker/refs/heads/main/assets/repos-ui.json
+          echo '{"os-checker/os-checker":{}}' > repos.json
 
-          echo '{"os-checker/os-checker-test-suite":{}}' > repos.json
+          # echo '{"os-checker/os-checker-test-suite":{}}' > repos.json
 
       - name: Install cargo-nextest
         run: |

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -57,31 +57,34 @@ jobs:
       # - name: Test pkg_targets
       #   run: cargo test -- test_pkg_targets --nocapture
 
-      - name: Install plugin-cargo
-        run: cargo install --path .
+      - name: Test get testcases
+        run: cargo test -- test_get_testcases --nocapture
 
-      - name: Run plugin-cargo
-        run: |
-          os-checker-plugin-cargo #os-checker.json
-          tree --gitignore -h cargo
-
-      - name: Push to database
-        env:
-          PLUGIN_PATH: plugin/cargo
-        run: |
-          git config --global user.name "zjp-CN[bot]"
-          git config --global user.email "zjp-CN[bot]@users.noreply.github.com"
-
-          echo "正在 clone os-checker/database"
-          gh repo clone os-checker/database
-          gh auth setup-git
-          echo "成功 clone os-checker/database"
-
-          cd database
-          git switch ${{ env.DATABASE }}
-
-          rm -rf ${{ env.PLUGIN_PATH }}
-          mkdir -p ${{ env.PLUGIN_PATH }}
-          mv ../cargo ${{ env.PLUGIN_PATH }}/info
-          bash ../push.sh
+      # - name: Install plugin-cargo
+      #   run: cargo install --path .
+      #
+      # - name: Run plugin-cargo
+      #   run: |
+      #     os-checker-plugin-cargo #os-checker.json
+      #     tree --gitignore -h cargo
+      #
+      # - name: Push to database
+      #   env:
+      #     PLUGIN_PATH: plugin/cargo
+      #   run: |
+      #     git config --global user.name "zjp-CN[bot]"
+      #     git config --global user.email "zjp-CN[bot]@users.noreply.github.com"
+      #
+      #     echo "正在 clone os-checker/database"
+      #     gh repo clone os-checker/database
+      #     gh auth setup-git
+      #     echo "成功 clone os-checker/database"
+      #
+      #     cd database
+      #     git switch ${{ env.DATABASE }}
+      #
+      #     rm -rf ${{ env.PLUGIN_PATH }}
+      #     mkdir -p ${{ env.PLUGIN_PATH }}
+      #     mv ../cargo ${{ env.PLUGIN_PATH }}/info
+      #     bash ../push.sh
 

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -13,8 +13,8 @@ env:
   DATABASE: debug
   BOT: 1
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
-  # OS_CHECKER_CONFIGS: repos.json
-  OS_CHECKER_CONFIGS: repos-default.json repos-ui.json
+  OS_CHECKER_CONFIGS: repos.json
+  # OS_CHECKER_CONFIGS: repos-default.json repos-ui.json
 
 jobs:
   run:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -23,7 +23,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly-2024-12-03
           components: rustfmt, clippy, miri
 
       - name: Set up miri

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -10,7 +10,7 @@ env:
   CARGO_TERM_COLOR: always
   RUST_LOG: info
   # database branch
-  DATABASE: debug
+  DATABASE: main
   BOT: 1
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
   # OS_CHECKER_CONFIGS: repos.json

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
         with:
+          toolchain: nightly-2024-12-03
           components: rustfmt, clippy, miri
 
       - name: Set up miri

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -10,7 +10,7 @@ env:
   CARGO_TERM_COLOR: always
   RUST_LOG: info
   # database branch
-  DATABASE: main
+  DATABASE: debug
   BOT: 1
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
   # OS_CHECKER_CONFIGS: repos.json
@@ -31,11 +31,13 @@ jobs:
 
       - name: Fetch os-checker config JSONs
         run: |
-          gh release download -R kern-crates/.github -p os-checker_config.json
-          # temporarily disable qclic/e1000e-frame
-          jq 'del(."qclic/e1000e-frame")' os-checker_config.json > repos-default.json
-          wget https://raw.githubusercontent.com/os-checker/os-checker/refs/heads/main/assets/repos-ui.json
-          echo '{"os-checker/os-checker":{}}' > repos.json
+          # gh release download -R kern-crates/.github -p os-checker_config.json
+          # # temporarily disable qclic/e1000e-frame
+          # jq 'del(."qclic/e1000e-frame")' os-checker_config.json > repos-default.json
+          # wget https://raw.githubusercontent.com/os-checker/os-checker/refs/heads/main/assets/repos-ui.json
+          # echo '{"os-checker/os-checker":{}}' > repos.json
+
+          echo '{"os-checker/os-checker-test-suite":{}}' > repos.json
 
       - name: Install cargo-nextest
         run: |
@@ -57,35 +59,35 @@ jobs:
       #
       # - name: Test pkg_targets
       #   run: cargo test -- test_pkg_targets --nocapture
+      #
+      # - name: Test get testcases
+      #   run: cargo test -- test_get_testcases --include-ignored --nocapture
 
-      - name: Test get testcases
-        run: cargo test -- test_get_testcases --include-ignored --nocapture
+      - name: Install plugin-cargo
+        run: cargo install --path .
 
-      # - name: Install plugin-cargo
-      #   run: cargo install --path .
-      #
-      # - name: Run plugin-cargo
-      #   run: |
-      #     os-checker-plugin-cargo #os-checker.json
-      #     tree --gitignore -h cargo
-      #
-      # - name: Push to database
-      #   env:
-      #     PLUGIN_PATH: plugin/cargo
-      #   run: |
-      #     git config --global user.name "zjp-CN[bot]"
-      #     git config --global user.email "zjp-CN[bot]@users.noreply.github.com"
-      #
-      #     echo "正在 clone os-checker/database"
-      #     gh repo clone os-checker/database
-      #     gh auth setup-git
-      #     echo "成功 clone os-checker/database"
-      #
-      #     cd database
-      #     git switch ${{ env.DATABASE }}
-      #
-      #     rm -rf ${{ env.PLUGIN_PATH }}
-      #     mkdir -p ${{ env.PLUGIN_PATH }}
-      #     mv ../cargo ${{ env.PLUGIN_PATH }}/info
-      #     bash ../push.sh
+      - name: Run plugin-cargo
+        run: |
+          os-checker-plugin-cargo #os-checker.json
+          tree --gitignore -h cargo
+
+      - name: Push to database
+        env:
+          PLUGIN_PATH: plugin/cargo
+        run: |
+          git config --global user.name "zjp-CN[bot]"
+          git config --global user.email "zjp-CN[bot]@users.noreply.github.com"
+
+          echo "正在 clone os-checker/database"
+          gh repo clone os-checker/database
+          gh auth setup-git
+          echo "成功 clone os-checker/database"
+
+          cd database
+          git switch ${{ env.DATABASE }}
+
+          rm -rf ${{ env.PLUGIN_PATH }}
+          mkdir -p ${{ env.PLUGIN_PATH }}
+          mv ../cargo ${{ env.PLUGIN_PATH }}/info
+          bash ../push.sh
 

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -58,7 +58,7 @@ jobs:
       #   run: cargo test -- test_pkg_targets --nocapture
 
       - name: Test get testcases
-        run: cargo test -- test_get_testcases --nocapture
+        run: cargo test -- test_get_testcases --include-ignored --nocapture
 
       # - name: Install plugin-cargo
       #   run: cargo install --path .

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,6 +123,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "child_wait_timeout"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebf6d2ce6ff24bd43f6896fff032a712a78866e5d59854fbd48fa08ad95b0080"
+dependencies = [
+ "cc",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "color-eyre"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,6 +455,7 @@ dependencies = [
 name = "os-checker-plugin-cargo"
 version = "0.1.2"
 dependencies = [
+ "child_wait_timeout",
  "eyre",
  "nextest-metadata",
  "os-checker-plugin",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,6 +449,7 @@ dependencies = [
  "os-checker-plugin",
  "os-checker-types",
  "serde",
+ "strip-ansi-escapes",
  "tracing",
  "walkdir",
 ]
@@ -706,6 +707,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ff8ef943b384c414f54aefa961dd2bd853add74ec75e7ac74cf91dba62bcfa"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -874,10 +884,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "vte"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5022b5fbf9407086c180e9557be968742d839e68346af7792b8592489732197"
+dependencies = [
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte_generate_state_changes"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ os-checker-types = "0.4.1"
 strip-ansi-escapes = "0.2"
 serde = "1"
 
+child_wait_timeout = "0.1"
+
 walkdir = "2"
 nextest-metadata = "0.12"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/os-checker/plugin-cargo"
 [dependencies]
 plugin = { version = "0.1.2", package = "os-checker-plugin" }
 os-checker-types = "0.4.1"
-
+strip-ansi-escapes = "0.2"
 serde = "1"
 
 walkdir = "2"

--- a/repos.json
+++ b/repos.json
@@ -1,3 +1,3 @@
 {
-  "os-checker/os-checker": {}
+  "os-checker/os-checker-test-suite": {}
 }

--- a/src/crates_io/release_tarball.rs
+++ b/src/crates_io/release_tarball.rs
@@ -48,13 +48,13 @@ fn url(pkg: &str, version: &Version) -> String {
 
 fn get_last_release_info(pkg: &str, version: &Version) -> Result<TarballInfo> {
     let tarball = download_tarball(pkg, version)?;
-    Ok(TarballInfo::new(&tarball)?)
+    TarballInfo::new(&tarball)
 }
 
 impl IndexFile {
     pub fn get_last_release_info(&mut self) -> Result<()> {
         let last = self.data.last();
-        let last = last.with_context(|| format!(" index file is empty"))?;
+        let last = last.with_context(|| "index file is empty")?;
         self.tarball = Some(get_last_release_info(&self.pkg, &last.vers)?);
         Ok(())
     }

--- a/src/nextest/mod.rs
+++ b/src/nextest/mod.rs
@@ -184,6 +184,7 @@ impl Report {
 
 // NEXTEST_EXPERIMENTAL_LIBTEST_JSON=1 cargo nextest run --message-format libtest-json-plus
 #[test]
+#[ignore = "manually trigger this to avoid recursion"]
 fn run_and_parse() -> Result<()> {
     // Why doesn't this cause infinite test running?
     let Report {

--- a/src/repo/miri.rs
+++ b/src/repo/miri.rs
@@ -4,7 +4,7 @@ pub fn cargo_miri(pkg: &str, kind: &str, bin: &str, name: &str) -> Option<String
     let _span = error_span!("cargo miri test -p {pkg} --{kind} {bin} -- {name}").entered();
 
     let kind = format!("--{kind}");
-    let output = cmd!("cargo", "miri", "test", "-p", pkg, kind, bin, "--", name)
+    let output = dbg!(cmd!("cargo", "miri", "test", "-p", pkg, kind, bin, "--", name))
         .stderr_capture()
         .unchecked()
         .run()

--- a/src/repo/miri.rs
+++ b/src/repo/miri.rs
@@ -11,18 +11,20 @@ pub fn cargo_miri(
     bin: &str,
     name: &str,
     workspace_root: &Utf8Path,
-) -> Option<String> {
+) -> (Option<String>, bool) {
     let kind = format!("--{kind}");
     let cmd = format!("cargo miri test -p {pkg} {kind} {bin} -- {name}");
     let _span = error_span!("miri", cmd).entered();
 
-    let mut child = Command::new("cargo")
+    let Ok(mut child) = Command::new("cargo")
         .args(["miri", "test", "-p", pkg, &kind, bin, "--", name])
         .stderr(Stdio::piped())
         .current_dir(workspace_root)
         .spawn()
         .map_err(|err| error!("Failed to spawn miri command: {err}"))
-        .ok()?;
+    else {
+        return (None, false);
+    };
 
     let minutes = 2;
     let success = match child.wait_timeout(Duration::from_secs(minutes * 60)) {
@@ -31,12 +33,12 @@ pub fn cargo_miri(
         Err(e) if e.kind() == std::io::ErrorKind::TimedOut => {
             let err = format!("Process timed out for {minutes} minutes.");
             error!(err);
-            return Some(format!("cmd={cmd}\n{err}"));
+            return (Some(format!("cmd={cmd}\n{err}")), true);
         }
         Err(e) => {
             let err = format!("Failed to wait on process: {e:?}");
             error!(err);
-            return Some(format!("cmd={cmd}\n{err}"));
+            return (Some(format!("cmd={cmd}\n{err}")), false);
         }
     };
 
@@ -44,25 +46,25 @@ pub fn cargo_miri(
         // stderr may contain compilation information like
         // stderr="    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.06s\n
         // Running unittests src/lib.rs (target/miri/x86_64-unknown-linux-gnu/debug/deps/os_checker_plugin_cargo-457c2a400d4e8077)\n"
-        return None;
+        return (None, false);
     }
 
     let Some(mut stderr_child) = child.stderr else {
         error!("Child stderr is unavailable.");
-        return None;
+        return (None, false);
     };
 
     let mut stderr_buf = Vec::with_capacity(1024);
     if let Err(err) = stderr_child.read_to_end(&mut stderr_buf) {
         error!("Failed to read stderr: {err}");
-        return None;
+        return (None, false);
     };
 
     let stderr = String::from_utf8(strip_ansi_escapes::strip(stderr_buf))
         .map_err(|err| error!("{err}: Non-utf8 output is emitted."))
-        .ok()?;
+        .ok();
 
-    Some(stderr)
+    (stderr, false)
 }
 
 #[test]
@@ -74,6 +76,7 @@ fn miri_output() {
         "miri_should_err",
         ".".into(),
     )
+    .0
     .unwrap();
     eprintln!("{stderr}");
 }

--- a/src/repo/miri.rs
+++ b/src/repo/miri.rs
@@ -1,11 +1,19 @@
+use os_checker_types::Utf8Path;
 use plugin::prelude::duct::cmd;
 
-pub fn cargo_miri(pkg: &str, kind: &str, bin: &str, name: &str) -> Option<String> {
+pub fn cargo_miri(
+    pkg: &str,
+    kind: &str,
+    bin: &str,
+    name: &str,
+    workspace_root: &Utf8Path,
+) -> Option<String> {
     let _span = error_span!("miri", "cargo miri test -p {pkg} --{kind} {bin} -- {name}").entered();
 
     let kind = format!("--{kind}");
     info!("cargo miri test -p {pkg} {kind} {bin} -- {name}");
     let output = cmd!("cargo", "miri", "test", "-p", pkg, kind, bin, "--", name)
+        .dir(workspace_root)
         .stderr_capture()
         .unchecked()
         .run()
@@ -28,6 +36,13 @@ pub fn cargo_miri(pkg: &str, kind: &str, bin: &str, name: &str) -> Option<String
 
 #[test]
 fn miri_output() {
-    let stderr = cargo_miri("os-checker-plugin-cargo", "test", "t1", "miri_should_err").unwrap();
+    let stderr = cargo_miri(
+        "os-checker-plugin-cargo",
+        "test",
+        "t1",
+        "miri_should_err",
+        ".".into(),
+    )
+    .unwrap();
     eprintln!("{stderr}");
 }

--- a/src/repo/miri.rs
+++ b/src/repo/miri.rs
@@ -4,7 +4,8 @@ pub fn cargo_miri(pkg: &str, kind: &str, bin: &str, name: &str) -> Option<String
     let _span = error_span!("cargo miri test -p {pkg} --{kind} {bin} -- {name}").entered();
 
     let kind = format!("--{kind}");
-    let output = dbg!(cmd!("cargo", "miri", "test", "-p", pkg, kind, bin, "--", name))
+    info!("cargo miri test -p {pkg} {kind} {bin} -- {name}");
+    let output = cmd!("cargo", "miri", "test", "-p", pkg, kind, bin, "--", name)
         .stderr_capture()
         .unchecked()
         .run()

--- a/src/repo/miri.rs
+++ b/src/repo/miri.rs
@@ -1,5 +1,9 @@
 use os_checker_types::Utf8Path;
-use plugin::prelude::duct::cmd;
+
+use child_wait_timeout::ChildWT;
+use std::io::Read;
+use std::process::{Command, Stdio};
+use std::time::Duration;
 
 pub fn cargo_miri(
     pkg: &str,
@@ -12,24 +16,55 @@ pub fn cargo_miri(
 
     let kind = format!("--{kind}");
     info!("cargo miri test -p {pkg} {kind} {bin} -- {name}");
-    let output = cmd!("cargo", "miri", "test", "-p", pkg, kind, bin, "--", name)
-        .dir(workspace_root)
-        .stderr_capture()
-        .unchecked()
-        .run()
-        .map_err(|err| error!(?err))
+    // let output = cmd!("cargo", "miri", "test", "-p", pkg, kind, bin, "--", name)
+    //     .dir(workspace_root)
+    //     .stderr_capture()
+    //     .unchecked()
+    //     .run()
+    //     .map_err(|err| error!(?err))
+    //     .ok()?;
+    let mut child = Command::new("cargo")
+        .args(["miri", "test", "-p", pkg, &kind, bin, "--", name])
+        .stderr(Stdio::piped())
+        .current_dir(workspace_root)
+        .spawn()
+        .map_err(|err| error!("Failed to spawn miri command: {err}"))
         .ok()?;
 
-    let stderr = String::from_utf8(strip_ansi_escapes::strip(output.stderr))
-        .map_err(|err| error!("{err}: Non-utf8 output is emitted."))
-        .ok()?;
+    let success = match child.wait_timeout(Duration::from_secs(2 * 60)) {
+        // Finished in 2 minutes
+        Ok(status) => status.success(),
+        Err(e) if e.kind() == std::io::ErrorKind::TimedOut => {
+            error!("Process timed out");
+            return None;
+        }
+        Err(e) => {
+            error!("Failed to wait on process: {:?}", e);
+            return None;
+        }
+    };
 
-    if output.status.success() {
+    if success {
         // stderr may contain compilation information like
         // stderr="    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.06s\n
         // Running unittests src/lib.rs (target/miri/x86_64-unknown-linux-gnu/debug/deps/os_checker_plugin_cargo-457c2a400d4e8077)\n"
         return None;
     }
+
+    let Some(mut stderr_child) = child.stderr else {
+        error!("Child stderr is unavailable.");
+        return None;
+    };
+
+    let mut stderr_buf = Vec::with_capacity(1024);
+    if let Err(err) = stderr_child.read_to_end(&mut stderr_buf) {
+        error!("Failed to read stderr: {err}");
+        return None;
+    };
+
+    let stderr = String::from_utf8(strip_ansi_escapes::strip(stderr_buf))
+        .map_err(|err| error!("{err}: Non-utf8 output is emitted."))
+        .ok()?;
 
     Some(stderr)
 }

--- a/src/repo/miri.rs
+++ b/src/repo/miri.rs
@@ -1,7 +1,7 @@
 use plugin::prelude::duct::cmd;
 
 pub fn cargo_miri(pkg: &str, kind: &str, bin: &str, name: &str) -> Option<String> {
-    let _span = error_span!("cargo miri test -p {pkg} --{kind} {bin} -- {name}").entered();
+    let _span = error_span!("miri", "cargo miri test -p {pkg} --{kind} {bin} -- {name}").entered();
 
     let kind = format!("--{kind}");
     info!("cargo miri test -p {pkg} {kind} {bin} -- {name}");
@@ -17,9 +17,9 @@ pub fn cargo_miri(pkg: &str, kind: &str, bin: &str, name: &str) -> Option<String
         .ok()?;
 
     if output.status.success() {
-        if !stderr.is_empty() {
-            error!(stderr);
-        }
+        // stderr may contain compilation information like
+        // stderr="    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.06s\n
+        // Running unittests src/lib.rs (target/miri/x86_64-unknown-linux-gnu/debug/deps/os_checker_plugin_cargo-457c2a400d4e8077)\n"
         return None;
     }
 

--- a/src/repo/miri.rs
+++ b/src/repo/miri.rs
@@ -26,7 +26,7 @@ pub fn cargo_miri(
         return (None, false, false);
     };
 
-    let minutes = 2;
+    let minutes = 1;
     let success = match child.wait_timeout(Duration::from_secs(minutes * 60)) {
         // Finished in 2 minutes
         Ok(status) => status.success(),

--- a/src/repo/miri.rs
+++ b/src/repo/miri.rs
@@ -1,0 +1,32 @@
+use plugin::prelude::duct::cmd;
+
+pub fn cargo_miri(pkg: &str, kind: &str, bin: &str, name: &str) -> Option<String> {
+    let _span = error_span!("cargo miri test -p {pkg} --{kind} {bin} -- {name}").entered();
+
+    let kind = format!("--{kind}");
+    let output = cmd!("cargo", "miri", "test", "-p", pkg, kind, bin, "--", name)
+        .stderr_capture()
+        .unchecked()
+        .run()
+        .map_err(|err| error!(?err))
+        .ok()?;
+
+    let stderr = String::from_utf8(strip_ansi_escapes::strip(output.stderr))
+        .map_err(|err| error!("{err}: Non-utf8 output is emitted."))
+        .ok()?;
+
+    if output.status.success() {
+        if !stderr.is_empty() {
+            error!(stderr);
+        }
+        return None;
+    }
+
+    Some(stderr)
+}
+
+#[test]
+fn miri_output() {
+    let stderr = cargo_miri("os-checker-plugin-cargo", "test", "t1", "miri_should_err").unwrap();
+    eprintln!("{stderr}");
+}

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -72,7 +72,7 @@ impl Repo {
         for workspace_root in self.workspaces.keys() {
             // NOTE: nextest is run under all packages in a workspace,
             // maybe we should run tests for each package?
-            map.extend(testcases::get(&self.dir, workspace_root)?);
+            map.extend(testcases::get(workspace_root)?);
         }
         Ok(map)
     }

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -6,6 +6,7 @@ use plugin::{prelude::*, write_json};
 use std::sync::LazyLock;
 use testcases::PkgTests;
 
+mod miri;
 mod os_checker;
 mod output;
 mod testcases;

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -63,7 +63,14 @@ impl Repo {
             .values()
             .flat_map(|ws| ws.workspace_packages())
             // but don't emit packages that are not checked by os-checker
-            .filter(|pkg| self.pkg_targets.contains_key(pkg.name.as_str()))
+            // FIXME: since --target is not supported in nextest and miri yet,
+            // we only run tests for x86_64-unknown-linux-gnu.
+            .filter(|pkg| {
+                self.pkg_targets
+                    .get(pkg.name.as_str())
+                    .map(|v| v.iter().any(|s| s == "x86_64-unknown-linux-gnu"))
+                    .unwrap_or(false)
+            })
             .collect()
     }
 

--- a/src/repo/testcases.rs
+++ b/src/repo/testcases.rs
@@ -148,3 +148,8 @@ impl TestBinary {
         }
     }
 }
+
+#[test]
+fn test_get_testcases() {
+    dbg!(get(".".into()).unwrap());
+}

--- a/src/repo/testcases.rs
+++ b/src/repo/testcases.rs
@@ -18,7 +18,9 @@ pub type PkgTests = IndexMap<String, TestCases>;
 pub fn get(workspace_root: &Utf8Path) -> Result<PkgTests> {
     let _span = error_span!("get_and_run", ?workspace_root).entered();
 
+    info!("test_list starts");
     let summary = test_list(workspace_root).with_context(|| "failed to get test list")?;
+    info!("run_testcases starts");
     let report = run_testcases(workspace_root).with_context(|| "failed to run tests")?;
 
     let workspace_tests_count = summary.test_count;
@@ -151,5 +153,6 @@ impl TestBinary {
 
 #[test]
 fn test_get_testcases() {
+    plugin::logger::init();
     dbg!(get(".".into()).unwrap());
 }

--- a/src/repo/testcases.rs
+++ b/src/repo/testcases.rs
@@ -95,16 +95,18 @@ pub struct TestCase {
     name: String,
     status: Option<Event>,
     duration_ms: Option<u32>,
+    error: Option<String>,
 }
 
 impl TestCase {
     pub fn new(name: &str, pkg_name: &str, bin_name: &str, report: &Report) -> Self {
-        let (status, duration_ms) = report.get_test_case(&[pkg_name, bin_name, name]);
+        let (status, duration_ms, error) = report.get_test_case(&[pkg_name, bin_name, name]);
         let name = name.to_owned();
         Self {
             name,
             status,
             duration_ms,
+            error,
         }
     }
 }

--- a/src/repo/testcases.rs
+++ b/src/repo/testcases.rs
@@ -15,7 +15,7 @@ pub type PkgTests = IndexMap<String, TestCases>;
 // FIXME: how should we handle doc tests?
 
 // nextest reports all member tests even if it's run under a member, so we just run under workspace
-pub fn get(repo_root: &Utf8Path, workspace_root: &Utf8Path) -> Result<PkgTests> {
+pub fn get(workspace_root: &Utf8Path) -> Result<PkgTests> {
     let _span = error_span!("get_and_run", ?workspace_root).entered();
 
     let summary = test_list(workspace_root).with_context(|| "failed to get test list")?;
@@ -34,7 +34,7 @@ pub fn get(repo_root: &Utf8Path, workspace_root: &Utf8Path) -> Result<PkgTests> 
             continue;
         }
 
-        let test = TestBinary::new(ele, &report, repo_root);
+        let test = TestBinary::new(ele, &report);
         if let Some((_, _, tests)) = map.get_full_mut(&ele.package_name) {
             tests.tests.push(test);
         } else {
@@ -115,7 +115,7 @@ impl TestCase {
 }
 
 impl TestBinary {
-    pub fn new(ele: &RustTestSuiteSummary, report: &Report, _repo_root: &Utf8Path) -> Self {
+    pub fn new(ele: &RustTestSuiteSummary, report: &Report) -> Self {
         let binary = &ele.binary;
         let pkg_name = &*ele.package_name;
         let bin_name = &*binary.binary_name;

--- a/src/repo/testcases.rs
+++ b/src/repo/testcases.rs
@@ -98,7 +98,8 @@ pub struct TestCase {
     status: Option<Event>,
     duration_ms: Option<u32>,
     error: Option<String>,
-    miri: Option<String>,
+    miri_pass: bool,
+    miri_output: Option<String>,
     miri_timeout: bool,
 }
 
@@ -111,7 +112,7 @@ impl TestCase {
         report: &Report,
         workspace_root: &Utf8Path,
     ) -> Self {
-        let (miri, miri_timeout) =
+        let (miri_output, miri_pass, miri_timeout) =
             super::miri::cargo_miri(pkg_name, kind, bin_name, name, workspace_root);
         let (status, duration_ms, error) = report.get_test_case(&[pkg_name, bin_name, name]);
         let name = name.to_owned();
@@ -120,7 +121,8 @@ impl TestCase {
             status,
             duration_ms,
             error,
-            miri,
+            miri_pass,
+            miri_output,
             miri_timeout,
         }
     }

--- a/src/repo/testcases.rs
+++ b/src/repo/testcases.rs
@@ -152,7 +152,7 @@ impl TestBinary {
 }
 
 #[test]
-#[ignore = "manually trigger in case of recursion"]
+#[ignore = "manually trigger this to avoid recursion"]
 fn test_get_testcases() {
     plugin::logger::init();
     dbg!(get(".".into()).unwrap());

--- a/src/repo/testcases.rs
+++ b/src/repo/testcases.rs
@@ -99,6 +99,7 @@ pub struct TestCase {
     duration_ms: Option<u32>,
     error: Option<String>,
     miri: Option<String>,
+    miri_timeout: bool,
 }
 
 impl TestCase {
@@ -110,7 +111,8 @@ impl TestCase {
         report: &Report,
         workspace_root: &Utf8Path,
     ) -> Self {
-        let miri = super::miri::cargo_miri(pkg_name, kind, bin_name, name, workspace_root);
+        let (miri, miri_timeout) =
+            super::miri::cargo_miri(pkg_name, kind, bin_name, name, workspace_root);
         let (status, duration_ms, error) = report.get_test_case(&[pkg_name, bin_name, name]);
         let name = name.to_owned();
         Self {
@@ -119,6 +121,7 @@ impl TestCase {
             duration_ms,
             error,
             miri,
+            miri_timeout,
         }
     }
 }

--- a/src/repo/testcases.rs
+++ b/src/repo/testcases.rs
@@ -152,6 +152,7 @@ impl TestBinary {
 }
 
 #[test]
+#[ignore = "manually trigger in case of recursion"]
 fn test_get_testcases() {
     plugin::logger::init();
     dbg!(get(".".into()).unwrap());

--- a/tests/nextest.stderr
+++ b/tests/nextest.stderr
@@ -1,10 +1,94 @@
-    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.53s
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.42s
 ------------
- Nextest run ID d8f6bdff-9e6c-41eb-b96b-384a7faf132f with nextest profile: default
-    Starting 4 tests across 3 binaries
-        PASS [   0.011s] os-checker-plugin-cargo from_lib
-        PASS [   0.012s] os-checker-plugin-cargo::t1 from_t1
-        PASS [   0.013s] os-checker-plugin-cargo::bin/os-checker-plugin-cargo from_main
-        PASS [   0.504s] os-checker-plugin-cargo repo::test_cargo_tomls
+ Nextest run ID 0fba453a-de6b-4ee7-9fa0-4eaea09c0d81 with nextest profile: default
+    Starting 12 tests across 3 binaries
+        PASS [   1.060s] os-checker-plugin-cargo crates_io::release_count::test_get_release_count
+        PASS [   1.295s] os-checker-plugin-cargo crates_io::release_tarball::test_tarball_info
+        FAIL [   0.005s] os-checker-plugin-cargo nextest::parse_stream
+
+--- OUTPUT:              os-checker-plugin-cargo nextest::parse_stream ---
+
+running 1 test
+[src/nextest/mod.rs:110:5] &reports = []
+thread 'nextest::parse_stream' panicked at src/nextest/mod.rs:111:5:
+assertion failed: !reports.is_empty()
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+test nextest::parse_stream ... FAILED
+
+failures:
+
+failures:
+    nextest::parse_stream
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 10 filtered out; finished in 0.00s
+
+
+        PASS [   0.005s] os-checker-plugin-cargo nextest::parse_test_event
+        PASS [   1.016s] os-checker-plugin-cargo database::test_diagnostics_count
+        PASS [   0.005s] os-checker-plugin-cargo nextest::string_to_name
+        FAIL [   0.042s] os-checker-plugin-cargo repo::os_checker::test_sel4
+
+--- OUTPUT:              os-checker-plugin-cargo repo::os_checker::test_sel4 ---
+
+running 1 test
+Error: Error: 
+   0: seL4/rust-sel4 is not in config repos:
+      {"os-checker/os-checker"}
+
+Location:
+   src/config/mod.rs:209
+
+Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
+Run with RUST_BACKTRACE=full to include source snippets.
+
+
+Location:
+    src/repo/os_checker.rs:25:5
+test repo::os_checker::test_sel4 ... FAILED
+
+failures:
+
+failures:
+    repo::os_checker::test_sel4
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 10 filtered out; finished in 0.04s
+
+
+        PASS [   0.311s] os-checker-plugin-cargo repo::test_cargo_tomls
+        PASS [   0.031s] os-checker-plugin-cargo repo::test_last_commit_time
+        FAIL [   0.010s] os-checker-plugin-cargo repo::test_pkg_targets
+
+--- OUTPUT:              os-checker-plugin-cargo repo::test_pkg_targets ---
+
+running 1 test
+Error: Error: 
+   0: seL4/rust-sel4 is not in config repos:
+      {"os-checker/os-checker"}
+
+Location:
+   src/config/mod.rs:209
+
+Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
+Run with RUST_BACKTRACE=full to include source snippets.
+
+
+Location:
+    src/repo/os_checker.rs:25:5
+test repo::test_pkg_targets ... FAILED
+
+failures:
+
+failures:
+    repo::test_pkg_targets
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 10 filtered out; finished in 0.00s
+
+
+        PASS [   0.005s] os-checker-plugin-cargo::t1 from_t1
+        PASS [  26.510s] os-checker-plugin-cargo nextest::run_and_parse
 ------------
-     Summary [   0.508s] 4 tests run: 4 passed, 0 skipped
+     Summary [  27.816s] 12 tests run: 9 passed, 3 failed, 0 skipped
+        FAIL [   0.005s] os-checker-plugin-cargo nextest::parse_stream
+        FAIL [   0.042s] os-checker-plugin-cargo repo::os_checker::test_sel4
+        FAIL [   0.010s] os-checker-plugin-cargo repo::test_pkg_targets
+error: test run failed

--- a/tests/nextest.stdout
+++ b/tests/nextest.stdout
@@ -1,14 +1,28 @@
 {"type":"suite","event":"started","test_count":1,"nextest":{"crate":"os-checker-plugin-cargo","test_binary":"t1","kind":"test"}}
 {"type":"test","event":"started","name":"os-checker-plugin-cargo::t1$from_t1"}
-{"type":"test","event":"ok","name":"os-checker-plugin-cargo::t1$from_t1","exec_time":0.012385435}
-{"type":"suite","event":"ok","passed":1,"failed":0,"ignored":0,"measured":0,"filtered_out":0,"exec_time":0.012385435,"nextest":{"crate":"os-checker-plugin-cargo","test_binary":"t1","kind":"test"}}
-{"type":"suite","event":"started","test_count":1,"nextest":{"crate":"os-checker-plugin-cargo","test_binary":"os-checker-plugin-cargo","kind":"bin"}}
-{"type":"test","event":"started","name":"os-checker-plugin-cargo::os-checker-plugin-cargo$from_main"}
-{"type":"test","event":"ok","name":"os-checker-plugin-cargo::os-checker-plugin-cargo$from_main","exec_time":0.012558923}
-{"type":"suite","event":"ok","passed":1,"failed":0,"ignored":0,"measured":0,"filtered_out":0,"exec_time":0.012558923,"nextest":{"crate":"os-checker-plugin-cargo","test_binary":"os-checker-plugin-cargo","kind":"bin"}}
-{"type":"suite","event":"started","test_count":2,"nextest":{"crate":"os-checker-plugin-cargo","test_binary":"os_checker_plugin_cargo","kind":"lib"}}
-{"type":"test","event":"started","name":"os-checker-plugin-cargo::os_checker_plugin_cargo$from_lib"}
+{"type":"test","event":"ok","name":"os-checker-plugin-cargo::t1$from_t1","exec_time":0.005025676}
+{"type":"suite","event":"ok","passed":1,"failed":0,"ignored":0,"measured":0,"filtered_out":0,"exec_time":0.005025676,"nextest":{"crate":"os-checker-plugin-cargo","test_binary":"t1","kind":"test"}}
+{"type":"suite","event":"started","test_count":11,"nextest":{"crate":"os-checker-plugin-cargo","test_binary":"os_checker_plugin_cargo","kind":"lib"}}
+{"type":"test","event":"started","name":"os-checker-plugin-cargo::os_checker_plugin_cargo$crates_io::release_count::test_get_release_count"}
+{"type":"test","event":"started","name":"os-checker-plugin-cargo::os_checker_plugin_cargo$crates_io::release_tarball::test_tarball_info"}
+{"type":"test","event":"ok","name":"os-checker-plugin-cargo::os_checker_plugin_cargo$crates_io::release_count::test_get_release_count","exec_time":1.059978523}
+{"type":"test","event":"started","name":"os-checker-plugin-cargo::os_checker_plugin_cargo$database::test_diagnostics_count"}
+{"type":"test","event":"ok","name":"os-checker-plugin-cargo::os_checker_plugin_cargo$crates_io::release_tarball::test_tarball_info","exec_time":1.295281179}
+{"type":"test","event":"started","name":"os-checker-plugin-cargo::os_checker_plugin_cargo$nextest::parse_stream"}
+{"type":"test","event":"failed","name":"os-checker-plugin-cargo::os_checker_plugin_cargo$nextest::parse_stream","exec_time":0.005492276,"stdout":"[src/nextest/mod.rs:110:5] &reports = []\nthread 'nextest::parse_stream' panicked at src/nextest/mod.rs:111:5:\nassertion failed: !reports.is_empty()\nnote: run with `RUST_BACKTRACE=1` environment variable to display a backtrace\n"}
+{"type":"test","event":"started","name":"os-checker-plugin-cargo::os_checker_plugin_cargo$nextest::parse_test_event"}
+{"type":"test","event":"ok","name":"os-checker-plugin-cargo::os_checker_plugin_cargo$nextest::parse_test_event","exec_time":0.004827423}
+{"type":"test","event":"started","name":"os-checker-plugin-cargo::os_checker_plugin_cargo$nextest::run_and_parse"}
+{"type":"test","event":"ok","name":"os-checker-plugin-cargo::os_checker_plugin_cargo$database::test_diagnostics_count","exec_time":1.016377764}
+{"type":"test","event":"started","name":"os-checker-plugin-cargo::os_checker_plugin_cargo$nextest::string_to_name"}
+{"type":"test","event":"ok","name":"os-checker-plugin-cargo::os_checker_plugin_cargo$nextest::string_to_name","exec_time":0.004807401}
+{"type":"test","event":"started","name":"os-checker-plugin-cargo::os_checker_plugin_cargo$repo::os_checker::test_sel4"}
+{"type":"test","event":"failed","name":"os-checker-plugin-cargo::os_checker_plugin_cargo$repo::os_checker::test_sel4","exec_time":0.041799556,"stdout":"Error: Error: \n   0: \u001b[91mseL4/rust-sel4 is not in config repos:\n      {\"os-checker/os-checker\"}\u001b[0m\n\nLocation:\n   \u001b[35msrc/config/mod.rs\u001b[0m:\u001b[35m209\u001b[0m\n\nBacktrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.\nRun with RUST_BACKTRACE=full to include source snippets.\n\n\nLocation:\n    src/repo/os_checker.rs:25:5\n"}
 {"type":"test","event":"started","name":"os-checker-plugin-cargo::os_checker_plugin_cargo$repo::test_cargo_tomls"}
-{"type":"test","event":"ok","name":"os-checker-plugin-cargo::os_checker_plugin_cargo$from_lib","exec_time":0.011477933}
-{"type":"test","event":"ok","name":"os-checker-plugin-cargo::os_checker_plugin_cargo$repo::test_cargo_tomls","exec_time":0.503863582}
-{"type":"suite","event":"ok","passed":2,"failed":0,"ignored":0,"measured":0,"filtered_out":0,"exec_time":0.515341515,"nextest":{"crate":"os-checker-plugin-cargo","test_binary":"os_checker_plugin_cargo","kind":"lib"}}
+{"type":"test","event":"ok","name":"os-checker-plugin-cargo::os_checker_plugin_cargo$repo::test_cargo_tomls","exec_time":0.31056857}
+{"type":"test","event":"started","name":"os-checker-plugin-cargo::os_checker_plugin_cargo$repo::test_last_commit_time"}
+{"type":"test","event":"ok","name":"os-checker-plugin-cargo::os_checker_plugin_cargo$repo::test_last_commit_time","exec_time":0.031440264}
+{"type":"test","event":"started","name":"os-checker-plugin-cargo::os_checker_plugin_cargo$repo::test_pkg_targets"}
+{"type":"test","event":"failed","name":"os-checker-plugin-cargo::os_checker_plugin_cargo$repo::test_pkg_targets","exec_time":0.009527343,"stdout":"Error: Error: \n   0: \u001b[91mseL4/rust-sel4 is not in config repos:\n      {\"os-checker/os-checker\"}\u001b[0m\n\nLocation:\n   \u001b[35msrc/config/mod.rs\u001b[0m:\u001b[35m209\u001b[0m\n\nBacktrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.\nRun with RUST_BACKTRACE=full to include source snippets.\n\n\nLocation:\n    src/repo/os_checker.rs:25:5\n"}
+{"type":"test","event":"ok","name":"os-checker-plugin-cargo::os_checker_plugin_cargo$nextest::run_and_parse","exec_time":26.509772712}
+{"type":"suite","event":"failed","passed":8,"failed":3,"ignored":0,"measured":0,"filtered_out":0,"exec_time":30.289873011,"nextest":{"crate":"os-checker-plugin-cargo","test_binary":"os_checker_plugin_cargo","kind":"lib"}}

--- a/tests/t1.rs
+++ b/tests/t1.rs
@@ -1,2 +1,8 @@
 #[test]
 fn from_t1() {}
+
+#[test]
+fn miri_should_err() {
+    let ptr = std::ptr::null_mut::<u8>();
+    unsafe { *ptr = 1 };
+}


### PR DESCRIPTION
由于 miri 与测试采用几乎相同的方式运行，因此将 miri 集成到 plugin-cargo 而不是 os-checker CLI.

os-checker CLI 暂时只检查主代码库，而不检查测试、示例等（即 tests 和 examples 等目录中的）代码。这是因为，如果 CLI 集成 miri ，意味着在两个地方重复代码来获取测试名称，此外运行 miri 可能花费未知的时间 —— 目前完整的静态检查已经需要至少 2 小时，而 miri 可能花费 6 小时直到 Github Runne 被杀死都还卡在一个测试上。

所以，运行 miri 需要附带一个超时，当超时阈值设置为 2 分钟，需要 2 小时才能完整检查完（含测试，不过根据历史数据，测试只需要不到半小时）；当设置为 1 分钟，可能节省 20 分钟。目前设置了 1 分钟超时，超时情况下，miri 检查的结果是不通过，并且写入超时到 miri_output 字段。

```rust
pub struct TestCase {
    ...
    // 以下为此 PR 增加的字段
    error: Option<String>, // 测试失败的输出
    miri_pass: bool, // 是否通过 miri
    miri_output: Option<String>, // miri 失败的输出
    miri_timeout: bool, // 运行 miri 是否超时
}
```

此外，为了更快运行完 CI，我暂时排除了非 x86_64-unknown-linux-gnu 目标的测试。将来需要
* 实现数据库缓存，跳过曾经运行过的测试，见 https://github.com/os-checker/plugin-cargo/issues/18
* 考虑支持 --target ；注意 miri 对非 tier 1 目标平台的支持非常不充分，目前只会在 x86_64-unknown-linux-gnu 上运行 miri，见 https://github.com/os-checker/os-checker/issues/12