### PR TITLE
fix: 生成 os-checker 指定的 packages 信息，并且只在 x86_64-unknown-linux-gnu 上运行测试和 miri 

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -4,17 +4,17 @@ on:
   schedule:
     - cron: '0 0 * * *'
   push:
-    branches: [ main, feat/* ]
+    branches: [ main, feat/*, fix/* ]
 
 env:
   CARGO_TERM_COLOR: always
   RUST_LOG: info
   # database branch
-  DATABASE: main
+  DATABASE: debug
   BOT: 1
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
-  # OS_CHECKER_CONFIGS: repos.json
-  OS_CHECKER_CONFIGS: repos-default.json repos-ui.json
+  OS_CHECKER_CONFIGS: repos.json
+  # OS_CHECKER_CONFIGS: repos-default.json repos-ui.json
 
 jobs:
   run:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -10,11 +10,11 @@ env:
   CARGO_TERM_COLOR: always
   RUST_LOG: info
   # database branch
-  DATABASE: debug
+  DATABASE: main
   BOT: 1
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
-  OS_CHECKER_CONFIGS: repos.json
-  # OS_CHECKER_CONFIGS: repos-default.json repos-ui.json
+  # OS_CHECKER_CONFIGS: repos.json
+  OS_CHECKER_CONFIGS: repos-default.json repos-ui.json
 
 jobs:
   run:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -34,9 +34,8 @@ jobs:
           # temporarily disable qclic/e1000e-frame
           jq 'del(."qclic/e1000e-frame")' os-checker_config.json > repos-default.json
           wget https://raw.githubusercontent.com/os-checker/os-checker/refs/heads/main/assets/repos-ui.json
-          echo '{"os-checker/os-checker":{}}' > repos.json
 
-          # echo '{"os-checker/os-checker-test-suite":{}}' > repos.json
+          # echo '{"os-checker/os-checker":{}}' > repos.json
 
       - name: Install cargo-nextest
         run: |

--- a/repos.json
+++ b/repos.json
@@ -1,3 +1,57 @@
 {
-  "os-checker/os-checker-test-suite": {}
+  "Starry-OS/Starry-New": {
+    "packages": {
+      "bwbench-client": {
+        "targets": "x86_64-unknown-linux-gnu"
+      },
+      "deptool": {
+        "targets": "x86_64-unknown-linux-gnu"
+      },
+      "arceos-shell": {
+        "targets": "x86_64-unknown-linux-gnu"
+      },
+      "arceos-tls": {
+        "targets": "x86_64-unknown-linux-gnu"
+      },
+      "arceos-echoserver": {
+        "targets": "x86_64-unknown-linux-gnu"
+      },
+      "arceos-priority": {
+        "targets": "x86_64-unknown-linux-gnu"
+      },
+      "arceos-udpserver": {
+        "targets": "x86_64-unknown-linux-gnu"
+      },
+      "arceos-httpserver": {
+        "targets": "x86_64-unknown-linux-gnu"
+      },
+      "arceos-httpclient": {
+        "targets": "x86_64-unknown-linux-gnu"
+      },
+      "arceos-memtest": {
+        "targets": "x86_64-unknown-linux-gnu"
+      },
+      "arceos-parallel": {
+        "targets": "x86_64-unknown-linux-gnu"
+      },
+      "arceos-sleep": {
+        "targets": "x86_64-unknown-linux-gnu"
+      },
+      "arceos-yield": {
+        "targets": "x86_64-unknown-linux-gnu"
+      },
+      "arceos-display": {
+        "targets": "x86_64-unknown-linux-gnu"
+      },
+      "arceos-exception": {
+        "targets": "x86_64-unknown-linux-gnu"
+      },
+      "arceos-helloworld": {
+        "targets": "x86_64-unknown-linux-gnu"
+      },
+      "mingo": {
+        "targets": "aarch64-unknown-none-softfloat"
+      }
+    }
+  }
 }

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -63,14 +63,7 @@ impl Repo {
             .values()
             .flat_map(|ws| ws.workspace_packages())
             // but don't emit packages that are not checked by os-checker
-            // FIXME: since --target is not supported in nextest and miri yet,
-            // we only run tests for x86_64-unknown-linux-gnu.
-            .filter(|pkg| {
-                self.pkg_targets
-                    .get(pkg.name.as_str())
-                    .map(|v| v.iter().any(|s| s == "x86_64-unknown-linux-gnu"))
-                    .unwrap_or(false)
-            })
+            .filter(|pkg| self.pkg_targets.get(pkg.name.as_str()).is_some())
             .collect()
     }
 
@@ -79,6 +72,8 @@ impl Repo {
         for workspace_root in self.workspaces.keys() {
             // NOTE: nextest is run under all packages in a workspace,
             // maybe we should run tests for each package?
+            // FIXME: since --target is not supported in nextest and miri yet,
+            // we should tell don't them not run tests other than on x86_64-unknown-linux-gnu.
             map.extend(testcases::get(workspace_root)?);
         }
         Ok(map)

--- a/src/repo/os_checker.rs
+++ b/src/repo/os_checker.rs
@@ -32,7 +32,6 @@ pub fn run(user_repo: &str) -> Result<PkgTargets> {
 
     let targets = std::fs::read_to_string(OUT)
         .with_context(|| format!("Layout output file {OUT} doesn't exist."))?;
-    println!("targets=\n{targets}");
     let v: Vec<ListTargets> = serde_json::from_str(&targets)?;
     Ok(list_to_map(v))
 }

--- a/src/repo/os_checker.rs
+++ b/src/repo/os_checker.rs
@@ -28,6 +28,7 @@ pub fn run(user_repo: &str) -> Result<PkgTargets> {
         std::str::from_utf8(&output.stderr)?
     );
 
+    println!("output=\n{}", std::str::from_utf8(&output.stdout).unwrap());
     let v: Vec<ListTargets> = serde_json::from_reader(output.stdout.as_slice())?;
     Ok(list_to_map(v))
 }


### PR DESCRIPTION
* close https://github.com/os-checker/plugin-cargo/issues/21
* close https://github.com/os-checker/plugin-cargo/issues/23