### PR TITLE
feat: add cache support

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -10,7 +10,7 @@ env:
   CARGO_TERM_COLOR: always
   RUST_LOG: info
   # database branch
-  DATABASE: debug
+  DATABASE: main
   TAG_CACHE: cache-plugin-cargo-v0.1.4.redb
   BOT: 1
   OS_CHECKER_FORCE_PLUGIN_CARGO: true

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -10,12 +10,12 @@ env:
   CARGO_TERM_COLOR: always
   RUST_LOG: info
   # database branch
-  DATABASE: main
+  DATABASE: debug
   TAG_CACHE: cache-plugin-cargo-v0.1.4.redb
   BOT: 1
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
-  # OS_CHECKER_CONFIGS: repos.json
-  OS_CHECKER_CONFIGS: repos-default.json repos-ui.json
+  OS_CHECKER_CONFIGS: os-checker.json
+  # OS_CHECKER_CONFIGS: repos-default.json repos-ui.json
 
 jobs:
   run:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -13,9 +13,10 @@ env:
   DATABASE: debug
   TAG_CACHE: cache-plugin-cargo-v0.1.4.redb
   BOT: 1
+  OS_CHECKER_FORCE_PLUGIN_CARGO: true
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
-  # OS_CHECKER_CONFIGS: os-checker.json
-  OS_CHECKER_CONFIGS: repos-default.json repos-ui.json
+  OS_CHECKER_CONFIGS: os-checker.json
+  # OS_CHECKER_CONFIGS: repos-default.json repos-ui.json
 
 jobs:
   run:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -11,6 +11,7 @@ env:
   RUST_LOG: info
   # database branch
   DATABASE: main
+  TAG_CACHE: cache-plugin-cargo-v0.1.4.redb
   BOT: 1
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
   # OS_CHECKER_CONFIGS: repos.json
@@ -27,6 +28,9 @@ jobs:
 
       - name: Set up miri
         run: cargo miri setup
+
+      - name: Download cache
+        run: gh release download -R os-checker/database ${{ env.TAG_CACHE }} -p cache.redb || echo "${{ env.TAG_CACHE }} not found"
 
       - name: Fetch os-checker config JSONs
         run: |
@@ -70,6 +74,13 @@ jobs:
         run: |
           os-checker-plugin-cargo #os-checker.json
           tree --gitignore -h cargo
+
+      - name: Upload cache
+        run: |
+          gh release upload --clobber -R os-checker/database ${{ env.TAG_CACHE }} ${{ env.TAG_CACHE }}
+          XZ_OPT=-e9 tar -cJvf ${{ env.TAG_CACHE }}.tar.xz ${{ env.TAG_CACHE }}
+          ls -alh
+          gh release upload --clobber -R os-checker/database ${{ env.TAG_CACHE }} ${{ env.TAG_CACHE }}.tar.xz
 
       - name: Push to database
         env:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -15,8 +15,8 @@ env:
   BOT: 1
   OS_CHECKER_FORCE_PLUGIN_CARGO: true
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
-  OS_CHECKER_CONFIGS: os-checker.json
-  # OS_CHECKER_CONFIGS: repos-default.json repos-ui.json
+  # OS_CHECKER_CONFIGS: os-checker.json
+  OS_CHECKER_CONFIGS: repos-default.json repos-ui.json
 
 jobs:
   run:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -13,7 +13,7 @@ env:
   DATABASE: main
   TAG_CACHE: cache-plugin-cargo-v0.1.4.redb
   BOT: 1
-  OS_CHECKER_FORCE_PLUGIN_CARGO: true
+  OS_CHECKER_FORCE_PLUGIN_CARGO: false
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
   # OS_CHECKER_CONFIGS: os-checker.json
   OS_CHECKER_CONFIGS: repos-default.json repos-ui.json

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -30,7 +30,7 @@ jobs:
         run: cargo miri setup
 
       - name: Download cache
-        run: gh release download -R os-checker/database ${{ env.TAG_CACHE }} -p cache.redb || echo "${{ env.TAG_CACHE }} not found"
+        run: gh release download -R os-checker/database ${{ env.TAG_CACHE }} -p ${{ env.TAG_CACHE }} || echo "${{ env.TAG_CACHE }} not found"
 
       - name: Fetch os-checker config JSONs
         run: |

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -14,8 +14,8 @@ env:
   TAG_CACHE: cache-plugin-cargo-v0.1.4.redb
   BOT: 1
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
-  OS_CHECKER_CONFIGS: os-checker.json
-  # OS_CHECKER_CONFIGS: repos-default.json repos-ui.json
+  # OS_CHECKER_CONFIGS: os-checker.json
+  OS_CHECKER_CONFIGS: repos-default.json repos-ui.json
 
 jobs:
   run:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /target
 /tmp
+cache-plugin-cargo-v*.redb
+layout.json
+/cargo

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,6 +460,7 @@ dependencies = [
  "nextest-metadata",
  "os-checker-plugin",
  "os-checker-types",
+ "redb",
  "serde",
  "strip-ansi-escapes",
  "tracing",
@@ -539,9 +540,9 @@ dependencies = [
 
 [[package]]
 name = "redb"
-version = "2.2.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b1de48a7cf7ba193e81e078d17ee2b786236eed1d3f7c60f8a09545efc4925"
+checksum = "ea0a72cd7140de9fc3e318823b883abf819c20d478ec89ce880466dc2ef263c6"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ eyre = "0.6"
 # logger
 tracing = "0.1"
 
+redb = "2.4"
+
 # The profile that 'dist' will build with
 [profile.dist]
 inherits = "release"

--- a/os-checker.json
+++ b/os-checker.json
@@ -1,4 +1,3 @@
-[
-  "qclic/fdt-parser",
-  "os-checker/os-checker"
-]
+{
+  "os-checker/os-checker-test-suite": {}
+}

--- a/os-checker.json
+++ b/os-checker.json
@@ -1,3 +1,3 @@
 {
-  "os-checker/os-checker-test-suite": {}
+  "shilei-massclouds/arch_boot": {}
 }

--- a/src/cache/db.rs
+++ b/src/cache/db.rs
@@ -1,0 +1,34 @@
+use super::{CachedKey, CachedValue, Result};
+use redb::{Database, TableDefinition};
+
+const FILE: &str = "cache-plugin-cargo-v0.1.4.redb";
+const TABLE: TableDefinition<CachedKey, CachedValue> = TableDefinition::new("plugin-cargo");
+
+pub fn read_cache(key: &CachedKey) -> Result<Option<CachedValue>> {
+    let db = Database::create(FILE)?;
+    let read_txn = db.begin_read()?;
+    let table = read_txn.open_table(TABLE)?;
+    Ok(table.get(key)?.map(|val| val.value()))
+}
+
+#[test]
+fn test_os_checker_test_suite() -> Result<()> {
+    const FILE: &str = "cache-plugin-cargo-v-test.redb";
+
+    let (key, val) = super::gen_cache("os-checker/os-checker-test-suite")?;
+
+    let db = Database::create(FILE)?;
+
+    let write_txn = db.begin_write()?;
+    {
+        let mut table = write_txn.open_table(TABLE)?;
+        table.insert(&key, &val)?;
+    }
+    write_txn.commit()?;
+
+    let read_txn = db.begin_read()?;
+    let table = read_txn.open_table(TABLE)?;
+    assert_eq!(val.json(), table.get(&key)?.unwrap().value().json());
+
+    Ok(())
+}

--- a/src/cache/db.rs
+++ b/src/cache/db.rs
@@ -13,10 +13,14 @@ impl Db {
         let db = Database::create(FILE)?;
 
         // create table if not present
-        info!(
-            "[begin_write] open_table: {:?}",
-            db.begin_write()?.open_table(TABLE)
-        );
+        {
+            let write_txn = db.begin_write()?;
+            info!(
+                "[begin_write] open_table: {:?}",
+                write_txn.open_table(TABLE)
+            );
+            write_txn.commit()?;
+        }
         info!(
             "[begin_read] open_table: {:?} list tables = {:?}",
             db.begin_read()?.open_table(TABLE),

--- a/src/cache/db.rs
+++ b/src/cache/db.rs
@@ -50,7 +50,10 @@ fn test_os_checker_test_suite() -> Result<()> {
 
     let read_txn = db.begin_read()?;
     let table = read_txn.open_table(TABLE)?;
-    assert_eq!(val.json(), table.get(&key)?.unwrap().value().json());
+    assert_eq!(
+        val.into_json(),
+        table.get(&key)?.unwrap().value().into_json()
+    );
 
     Ok(())
 }

--- a/src/cache/db.rs
+++ b/src/cache/db.rs
@@ -1,5 +1,5 @@
 use super::{CachedKey, CachedValue, Result};
-use redb::{Database, TableDefinition, TableHandle};
+use redb::{Database, ReadableTableMetadata, TableDefinition, TableHandle};
 
 const FILE: &str = "cache-plugin-cargo-v0.1.4.redb";
 const TABLE: TableDefinition<CachedKey, CachedValue> = TableDefinition::new("plugin-cargo");
@@ -21,7 +21,8 @@ impl Db {
         {
             let read_txn = db.begin_read()?;
             info!(
-                "list tables = {:?}",
+                "len = {:?} list tables = {:?}",
+                read_txn.open_table(TABLE)?.len(),
                 read_txn
                     .list_tables()?
                     .map(|t| t.name().to_owned())
@@ -82,7 +83,6 @@ fn test_os_checker_test_suite() -> Result<()> {
 
 #[test]
 fn test_db_list_table() -> Result<()> {
-    use redb::ReadableTableMetadata;
     let db = Database::create(FILE)?;
 
     let read_txn = db.begin_read()?;

--- a/src/cache/db.rs
+++ b/src/cache/db.rs
@@ -1,5 +1,5 @@
 use super::{CachedKey, CachedValue, Result};
-use redb::{Database, TableDefinition};
+use redb::{Database, TableDefinition, TableHandle};
 
 const FILE: &str = "cache-plugin-cargo-v0.1.4.redb";
 const TABLE: TableDefinition<CachedKey, CachedValue> = TableDefinition::new("plugin-cargo");
@@ -18,8 +18,12 @@ impl Db {
             db.begin_write()?.open_table(TABLE)
         );
         info!(
-            "[begin_read] open_table: {:?}",
-            db.begin_read()?.open_table(TABLE)
+            "[begin_read] open_table: {:?} list tables = {:?}",
+            db.begin_read()?.open_table(TABLE),
+            db.begin_read()?
+                .list_tables()?
+                .map(|t| t.name().to_owned())
+                .collect::<Vec<_>>(),
         );
 
         Ok(Db { db })

--- a/src/cache/db.rs
+++ b/src/cache/db.rs
@@ -13,25 +13,37 @@ impl Db {
         let db = Database::create(FILE)?;
 
         // create table if not present
-        info!("open_table: {:?}", db.begin_write()?.open_table(TABLE));
+        info!(
+            "[begin_write] open_table: {:?}",
+            db.begin_write()?.open_table(TABLE)
+        );
+        info!(
+            "[begin_read] open_table: {:?}",
+            db.begin_read()?.open_table(TABLE)
+        );
 
         Ok(Db { db })
     }
 
     pub fn load_cache(&self, key: &CachedKey) -> Result<Option<CachedValue>> {
+        info!("begin to load cache");
         let read_txn = self.db.begin_read()?;
         let table = read_txn.open_table(TABLE)?;
-        Ok(table.get(key)?.map(|val| val.value()))
+        let val = table.get(key)?.map(|val| val.value());
+        info!("cache found");
+        Ok(val)
     }
 
     // TODO: add a timestamp for each store
     pub fn store_cache(&self, key: &CachedKey, val: &CachedValue) -> Result<()> {
+        info!("begin to store cache");
         let write_txn = self.db.begin_write()?;
         {
             let mut table = write_txn.open_table(TABLE)?;
             table.insert(key, val)?;
         }
         write_txn.commit()?;
+        info!("cache written");
         Ok(())
     }
 }

--- a/src/cache/db.rs
+++ b/src/cache/db.rs
@@ -10,9 +10,12 @@ pub struct Db {
 
 impl Db {
     pub fn open() -> Result<Self> {
-        Ok(Db {
-            db: Database::create(FILE)?,
-        })
+        let db = Database::create(FILE)?;
+
+        // create table if not present
+        info!("open_table: {:?}", db.begin_write()?.open_table(TABLE));
+
+        Ok(Db { db })
     }
 
     pub fn load_cache(&self, key: &CachedKey) -> Result<Option<CachedValue>> {

--- a/src/cache/db.rs
+++ b/src/cache/db.rs
@@ -15,17 +15,13 @@ impl Db {
         // create table if not present
         {
             let write_txn = db.begin_write()?;
-            info!(
-                "[begin_write] open_table: {:?}",
-                write_txn.open_table(TABLE)
-            );
+            write_txn.open_table(TABLE)?;
             write_txn.commit()?;
         }
         {
             let read_txn = db.begin_read()?;
             info!(
-                "[begin_read] open_table: {:?} list tables = {:?}",
-                read_txn.open_table(TABLE),
+                "list tables = {:?}",
                 read_txn
                     .list_tables()?
                     .map(|t| t.name().to_owned())

--- a/src/cache/db.rs
+++ b/src/cache/db.rs
@@ -21,14 +21,17 @@ impl Db {
             );
             write_txn.commit()?;
         }
-        info!(
-            "[begin_read] open_table: {:?} list tables = {:?}",
-            db.begin_read()?.open_table(TABLE),
-            db.begin_read()?
-                .list_tables()?
-                .map(|t| t.name().to_owned())
-                .collect::<Vec<_>>(),
-        );
+        {
+            let read_txn = db.begin_read()?;
+            info!(
+                "[begin_read] open_table: {:?} list tables = {:?}",
+                read_txn.open_table(TABLE),
+                read_txn
+                    .list_tables()?
+                    .map(|t| t.name().to_owned())
+                    .collect::<Vec<_>>(),
+            );
+        }
 
         Ok(Db { db })
     }

--- a/src/cache/db.rs
+++ b/src/cache/db.rs
@@ -83,3 +83,22 @@ fn test_os_checker_test_suite() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_db_list_table() -> Result<()> {
+    use redb::ReadableTableMetadata;
+    let db = Database::create(FILE)?;
+
+    let read_txn = db.begin_read()?;
+    let table = read_txn.open_table(TABLE)?;
+    println!(
+        "[begin_read] open_table: {table:?}\nlen = {:?}\nlist tables = {:?}",
+        table.len(),
+        read_txn
+            .list_tables()?
+            .map(|t| t.name().to_owned())
+            .collect::<Vec<_>>(),
+    );
+
+    Ok(())
+}

--- a/src/cache/db.rs
+++ b/src/cache/db.rs
@@ -96,5 +96,14 @@ fn test_db_list_table() -> Result<()> {
             .collect::<Vec<_>>(),
     );
 
+    use redb::ReadableTable;
+
+    let repo_with_err = table.iter()?.find_map(|t| {
+        let (k, v) = t.ok()?;
+        let (k, v) = (k.value(), v.value());
+        (k.user == "shilei-massclouds" && k.repo == "arch_boot").then_some(v)
+    });
+    dbg!(repo_with_err);
+
     Ok(())
 }

--- a/src/cache/gh.rs
+++ b/src/cache/gh.rs
@@ -1,0 +1,51 @@
+use super::{Api, CachedKey, Result};
+use os_checker_plugin_cargo::repo::split_user_repo;
+use plugin::prelude::{cmd, serde_json};
+
+const QUERY: &str = "query=
+query($owner: String!, $name: String!) {
+  repository(owner: $owner, name: $name) {
+    defaultBranchRef {
+      name
+      target {
+        ... on Commit {
+          oid
+        }
+      }
+    }
+  }
+}";
+
+/// gh api graphql -f query='
+///   query($owner: String!, $name: String!) {
+///     repository(owner: $owner, name: $name) {
+///       defaultBranchRef {
+///         name
+///         target {
+///           ... on Commit {
+///             oid
+///           }
+///         }
+///       }
+///     }
+///   }
+/// ' -F owner="os-checker" -F name="os-checker-test-suite" |
+///   jq ".data.repository.defaultBranchRef | {branch: .name, sha: .target.oid}"
+pub fn graphql_api(user_repo: &str) -> Result<CachedKey> {
+    let [user, repo] = split_user_repo(user_repo)?;
+    let owner = format!("owner={user}");
+    let name = format!("name={repo}");
+    let expr = cmd!("gh", "api", "graphql", "-f", QUERY, "-F", owner, "-F", name).pipe(cmd!(
+        "jq",
+        ".data.repository.defaultBranchRef | {branch: .name, sha: .target.oid}"
+    ));
+    let json = expr.read()?;
+    let api: Api = serde_json::from_str(&json)?;
+    Ok(CachedKey { user, repo, api })
+}
+
+#[test]
+fn test_github_graphql_api() -> Result<()> {
+    dbg!(graphql_api("os-checker/os-checker-test-suite")?);
+    Ok(())
+}

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -31,10 +31,11 @@ pub fn get_or_gen_cache(user_repo: &str) -> Result<(CachedKey, CachedValue)> {
     let _span = error_span!("cache", key = format!("{:?}", key.api)).entered();
 
     let db = db::Db::open()?;
-    let (key, val) = match db.load_cache(&key)? {
+    let (key, mut val) = match db.load_cache(&key)? {
         Some(val) => (key, val),
         None => gen_cache(user_repo)?,
     };
+    val.update_timestamp();
     db.store_cache(&key, &val)?;
     Ok((key, val))
 }

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1,104 +1,12 @@
 use crate::Result;
-use os_checker_plugin_cargo::repo::{split_user_repo, GitInfo, Repo};
+use os_checker_plugin_cargo::repo::{split_user_repo, Repo};
 use plugin::prelude::{cmd, serde_json};
 use redb::{Database, Error, ReadableTable, TableDefinition};
-use serde::{Deserialize, Serialize};
+
+mod types;
+pub use types::{Api, CachedKey, CachedValue};
 
 const TABLE: TableDefinition<CachedKey, CachedValue> = TableDefinition::new("plugin-cargo");
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct CachedKey {
-    user: String,
-    repo: String,
-    api: Api,
-}
-
-impl redb::Key for CachedKey {
-    fn compare(data1: &[u8], data2: &[u8]) -> std::cmp::Ordering {
-        data1.cmp(data2)
-    }
-}
-impl redb::Value for CachedKey {
-    type SelfType<'a>
-        = CachedKey
-    where
-        Self: 'a;
-
-    type AsBytes<'a>
-        = Vec<u8>
-    where
-        Self: 'a;
-
-    fn fixed_width() -> Option<usize> {
-        None
-    }
-
-    fn from_bytes<'a>(data: &'a [u8]) -> Self::SelfType<'a>
-    where
-        Self: 'a,
-    {
-        serde_json::from_slice(data).expect("Failed to deserialize CachedKey from bytes.")
-    }
-
-    fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> Self::AsBytes<'a>
-    where
-        Self: 'b,
-    {
-        serde_json::to_vec(value).expect("Failed to serialize CachedKey into bytes.")
-    }
-
-    fn type_name() -> redb::TypeName {
-        redb::TypeName::new("[plugin-cargo] CachedKey")
-    }
-}
-
-#[derive(Debug)]
-pub struct CachedValue {
-    inner: serde_json::Value,
-}
-
-impl CachedValue {
-    pub fn json(&self) -> &serde_json::Value {
-        &self.inner
-    }
-}
-
-impl redb::Value for CachedValue {
-    type SelfType<'a>
-        = Self
-    where
-        Self: 'a;
-
-    type AsBytes<'a>
-        = Vec<u8>
-    where
-        Self: 'a;
-
-    fn fixed_width() -> Option<usize> {
-        None
-    }
-
-    fn from_bytes<'a>(data: &'a [u8]) -> Self::SelfType<'a>
-    where
-        Self: 'a,
-    {
-        Self {
-            inner: serde_json::from_slice(data)
-                .expect("Failed to deserialize CachedValue from bytes."),
-        }
-    }
-
-    fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> Self::AsBytes<'a>
-    where
-        Self: 'b,
-    {
-        serde_json::to_vec(&value.inner).expect("Failed to serialize CachedValue into bytes.")
-    }
-
-    fn type_name() -> redb::TypeName {
-        redb::TypeName::new("[plugin-cargo] CachedValue")
-    }
-}
 
 /// Generate a new cached repo and its output regarding tests and package information.
 pub fn gen_cache(user_repo: &str) -> Result<(CachedKey, CachedValue)> {
@@ -111,7 +19,7 @@ pub fn gen_cache(user_repo: &str) -> Result<(CachedKey, CachedValue)> {
             repo: repo.repo,
             api: repo.git_info.into(),
         },
-        CachedValue { inner: output },
+        CachedValue::new(output),
     ))
 }
 
@@ -131,21 +39,6 @@ fn read_cache(key: &CachedKey) -> Result<Option<CachedValue>> {
     let read_txn = db.begin_read()?;
     let table = read_txn.open_table(TABLE)?;
     Ok(table.get(key)?.map(|val| val.value()))
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-struct Api {
-    branch: String,
-    sha: String,
-}
-
-impl From<GitInfo> for Api {
-    fn from(info: GitInfo) -> Self {
-        Api {
-            branch: info.branch,
-            sha: info.sha,
-        }
-    }
 }
 
 fn github_graphql_api(user_repo: &str) -> Result<CachedKey> {

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -11,7 +11,10 @@ mod gh;
 fn gen_cache(user_repo: &str) -> Result<(CachedKey, CachedValue)> {
     let repo = Repo::new(user_repo)?;
     let output = repo.output()?;
+
+    // remove local dir: all local operations must take place before this
     std::fs::remove_dir_all(&repo.dir)?;
+
     Ok((
         CachedKey {
             user: repo.user,

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -28,6 +28,8 @@ fn gen_cache(user_repo: &str) -> Result<(CachedKey, CachedValue)> {
 /// Get a local cache if any, otherwise download the repo and generate the cache.
 pub fn get_or_gen_cache(user_repo: &str) -> Result<(CachedKey, CachedValue)> {
     let key = gh::graphql_api(user_repo)?;
+    let _span = error_span!("cache", key = format!("{key:?}")).entered();
+
     let db = db::Db::open()?;
     let (key, val) = match db.load_cache(&key)? {
         Some(val) => (key, val),

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -22,11 +22,14 @@ fn gen_cache(user_repo: &str) -> Result<(CachedKey, CachedValue)> {
     ))
 }
 
+/// Get a local cache if any, otherwise download the repo and generate the cache.
 pub fn get_or_gen_cache(user_repo: &str) -> Result<(CachedKey, CachedValue)> {
     let key = gh::graphql_api(user_repo)?;
-    let (key, val) = match db::read_cache(&key)? {
+    let db = db::Db::open()?;
+    let (key, val) = match db.load_cache(&key)? {
         Some(val) => (key, val),
         None => gen_cache(user_repo)?,
     };
+    db.store_cache(&key, &val)?;
     Ok((key, val))
 }

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -10,7 +10,7 @@ mod gh;
 
 /// Output json when error happens.
 fn err_json(user: &str, repo: &str, err: &dyn std::error::Error) -> serde_json::Value {
-    let msg = strip_ansi_escapes::strip_str(format!("{err}"));
+    let msg = strip_ansi_escapes::strip_str(format!("{err:?}"));
     let now = os_checker_types::now();
     serde_json::json!({
         "user": user,

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -10,6 +10,7 @@ mod gh;
 
 /// Output json when error happens.
 fn err_json(user: &str, repo: &str, err: &dyn std::error::Error) -> serde_json::Value {
+    let msg = strip_ansi_escapes::strip_str(format!("{err:?}"));
     let now = os_checker_types::now();
     serde_json::json!({
         "user": user,
@@ -18,7 +19,7 @@ fn err_json(user: &str, repo: &str, err: &dyn std::error::Error) -> serde_json::
             "start": now,
             "end": now
         },
-        "err": format!("{err:?}")
+        "err": msg
     })
 }
 

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -23,12 +23,6 @@ fn err_json(user: &str, repo: &str, err: &dyn std::error::Error) -> serde_json::
     })
 }
 
-#[test]
-fn test_strip_color() {
-    let msg = "\"无法读取 cargo metadata 的结果：\\n`cargo metadata` exited with an e";
-    println!("{msg}");
-}
-
 /// Generate a new cached repo and its output regarding tests and package information.
 fn gen_cache(user_repo: &str) -> Result<(CachedKey, CachedValue)> {
     let repo = Repo::new(user_repo)?;

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1,15 +1,14 @@
 use crate::Result;
-use os_checker_plugin_cargo::repo::{split_user_repo, Repo};
-use plugin::prelude::{cmd, serde_json};
-use redb::{Database, Error, ReadableTable, TableDefinition};
+use os_checker_plugin_cargo::repo::Repo;
 
 mod types;
 pub use types::{Api, CachedKey, CachedValue};
 
-const TABLE: TableDefinition<CachedKey, CachedValue> = TableDefinition::new("plugin-cargo");
+mod db;
+mod gh;
 
 /// Generate a new cached repo and its output regarding tests and package information.
-pub fn gen_cache(user_repo: &str) -> Result<(CachedKey, CachedValue)> {
+fn gen_cache(user_repo: &str) -> Result<(CachedKey, CachedValue)> {
     let repo = Repo::new(user_repo)?;
     let output = repo.output()?;
     std::fs::remove_dir_all(&repo.dir)?;
@@ -23,90 +22,11 @@ pub fn gen_cache(user_repo: &str) -> Result<(CachedKey, CachedValue)> {
     ))
 }
 
-pub fn get_or_gen(user_repo: &str) -> Result<(CachedKey, CachedValue)> {
-    let key = github_graphql_api(user_repo)?;
-    let (key, val) = match read_cache(&key)? {
+pub fn get_or_gen_cache(user_repo: &str) -> Result<(CachedKey, CachedValue)> {
+    let key = gh::graphql_api(user_repo)?;
+    let (key, val) = match db::read_cache(&key)? {
         Some(val) => (key, val),
         None => gen_cache(user_repo)?,
     };
     Ok((key, val))
-}
-
-const FILE: &str = "cache-plugin-cargo-v0.1.4.redb";
-
-fn read_cache(key: &CachedKey) -> Result<Option<CachedValue>> {
-    let db = Database::create(FILE)?;
-    let read_txn = db.begin_read()?;
-    let table = read_txn.open_table(TABLE)?;
-    Ok(table.get(key)?.map(|val| val.value()))
-}
-
-fn github_graphql_api(user_repo: &str) -> Result<CachedKey> {
-    // gh api graphql -f query='
-    //   query($owner: String!, $name: String!) {
-    //     repository(owner: $owner, name: $name) {
-    //       defaultBranchRef {
-    //         name
-    //         target {
-    //           ... on Commit {
-    //             oid
-    //           }
-    //         }
-    //       }
-    //     }
-    //   }
-    // ' -F owner="os-checker" -F name="os-checker-test-suite" |
-    //   jq ".data.repository.defaultBranchRef | {branch: .name, sha: .target.oid}"
-    const QUERY: &str = "query=
-query($owner: String!, $name: String!) {
-  repository(owner: $owner, name: $name) {
-    defaultBranchRef {
-      name
-      target {
-        ... on Commit {
-          oid
-        }
-      }
-    }
-  }
-}";
-
-    let [user, repo] = split_user_repo(user_repo)?;
-    let owner = format!("owner={user}");
-    let name = format!("name={repo}");
-    let expr = cmd!("gh", "api", "graphql", "-f", QUERY, "-F", owner, "-F", name).pipe(cmd!(
-        "jq",
-        ".data.repository.defaultBranchRef | {branch: .name, sha: .target.oid}"
-    ));
-    let json = expr.read()?;
-    let api: Api = serde_json::from_str(&json)?;
-    Ok(CachedKey { user, repo, api })
-}
-
-#[test]
-fn test_os_checker_test_suite() -> Result<()> {
-    const FILE: &str = "cache-plugin-cargo-v-test.redb";
-
-    let (key, val) = gen_cache("os-checker/os-checker-test-suite")?;
-
-    let db = Database::create(FILE)?;
-
-    let write_txn = db.begin_write()?;
-    {
-        let mut table = write_txn.open_table(TABLE)?;
-        table.insert(&key, &val)?;
-    }
-    write_txn.commit()?;
-
-    let read_txn = db.begin_read()?;
-    let table = read_txn.open_table(TABLE)?;
-    assert_eq!(val.json(), table.get(&key)?.unwrap().value().json());
-
-    Ok(())
-}
-
-#[test]
-fn test_github_graphql_api() -> Result<()> {
-    dbg!(github_graphql_api("os-checker/os-checker-test-suite")?);
-    Ok(())
 }

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -10,7 +10,7 @@ mod gh;
 
 /// Output json when error happens.
 fn err_json(user: &str, repo: &str, err: &dyn std::error::Error) -> serde_json::Value {
-    let msg = strip_ansi_escapes::strip_str(format!("{err:?}"));
+    let msg = strip_ansi_escapes::strip_str(format!("{err}"));
     let now = os_checker_types::now();
     serde_json::json!({
         "user": user,
@@ -25,11 +25,8 @@ fn err_json(user: &str, repo: &str, err: &dyn std::error::Error) -> serde_json::
 
 #[test]
 fn test_strip_color() {
-    if let Err(err) = Repo::new("shilei-massclouds/arch_boot") {
-        println!("raw msg=\n{err:?}");
-        let msg = strip_ansi_escapes::strip_str(format!("{err:?}"));
-        println!("\n{msg}");
-    }
+    let msg = "\"无法读取 cargo metadata 的结果：\\n`cargo metadata` exited with an e";
+    println!("{msg}");
 }
 
 /// Generate a new cached repo and its output regarding tests and package information.

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -28,7 +28,7 @@ fn gen_cache(user_repo: &str) -> Result<(CachedKey, CachedValue)> {
 /// Get a local cache if any, otherwise download the repo and generate the cache.
 pub fn get_or_gen_cache(user_repo: &str) -> Result<(CachedKey, CachedValue)> {
     let key = gh::graphql_api(user_repo)?;
-    let _span = error_span!("cache", key = format!("{key:?}")).entered();
+    let _span = error_span!("cache", key = format!("{:?}", key.api)).entered();
 
     let db = db::Db::open()?;
     let (key, val) = match db.load_cache(&key)? {

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1,5 +1,6 @@
 use crate::Result;
 use os_checker_plugin_cargo::repo::Repo;
+use plugin::prelude::serde_json;
 
 mod types;
 pub use types::{Api, CachedKey, CachedValue};
@@ -7,10 +8,27 @@ pub use types::{Api, CachedKey, CachedValue};
 mod db;
 mod gh;
 
+/// Output json when error happens.
+fn err_json(user: &str, repo: &str, err: &dyn std::error::Error) -> serde_json::Value {
+    let now = os_checker_types::now();
+    serde_json::json!({
+        "user": user,
+        "repo": repo,
+        "timestamp": {
+            "start": now,
+            "end": now
+        },
+        "err": format!("{err:?}")
+    })
+}
+
 /// Generate a new cached repo and its output regarding tests and package information.
 fn gen_cache(user_repo: &str) -> Result<(CachedKey, CachedValue)> {
     let repo = Repo::new(user_repo)?;
-    let output = repo.output()?;
+    let output = match repo.output() {
+        Ok(output) => output,
+        Err(err) => err_json(&repo.user, &repo.repo, err.as_ref()),
+    };
 
     // remove local dir: all local operations must take place before this
     std::fs::remove_dir_all(&repo.dir)?;
@@ -33,7 +51,13 @@ pub fn get_or_gen_cache(user_repo: &str) -> Result<(CachedKey, CachedValue)> {
     let db = db::Db::open()?;
     let (key, mut val) = match db.load_cache(&key)? {
         Some(val) => (key, val),
-        None => gen_cache(user_repo)?,
+        None => match gen_cache(user_repo) {
+            Ok(cache) => cache,
+            Err(err) => {
+                let val = CachedValue::new(err_json(&key.user, &key.repo, err.as_ref()));
+                (key, val)
+            }
+        },
     };
     val.update_timestamp();
     db.store_cache(&key, &val)?;

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1,0 +1,140 @@
+use crate::Result;
+use os_checker_plugin_cargo::repo::{GitInfo, Repo};
+use plugin::prelude::serde_json;
+use redb::{Database, Error, ReadableTable, TableDefinition};
+use serde::{Deserialize, Serialize};
+
+const TABLE: TableDefinition<CachedKey, CachedValue> = TableDefinition::new("plugin-cargo");
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CachedKey {
+    user: String,
+    repo: String,
+    git_info: GitInfo,
+}
+
+impl CachedKey {}
+
+impl redb::Key for CachedKey {
+    fn compare(data1: &[u8], data2: &[u8]) -> std::cmp::Ordering {
+        data1.cmp(data2)
+    }
+}
+impl redb::Value for CachedKey {
+    type SelfType<'a>
+        = CachedKey
+    where
+        Self: 'a;
+
+    type AsBytes<'a>
+        = Vec<u8>
+    where
+        Self: 'a;
+
+    fn fixed_width() -> Option<usize> {
+        None
+    }
+
+    fn from_bytes<'a>(data: &'a [u8]) -> Self::SelfType<'a>
+    where
+        Self: 'a,
+    {
+        serde_json::from_slice(data).expect("Failed to deserialize CachedKey from bytes.")
+    }
+
+    fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> Self::AsBytes<'a>
+    where
+        Self: 'b,
+    {
+        serde_json::to_vec(value).expect("Failed to serialize CachedKey into bytes.")
+    }
+
+    fn type_name() -> redb::TypeName {
+        redb::TypeName::new("[plugin-cargo] CachedKey")
+    }
+}
+
+#[derive(Debug)]
+pub struct CachedValue {
+    inner: serde_json::Value,
+}
+
+impl CachedValue {
+    pub fn json(&self) -> &serde_json::Value {
+        &self.inner
+    }
+}
+
+impl redb::Value for CachedValue {
+    type SelfType<'a>
+        = Self
+    where
+        Self: 'a;
+
+    type AsBytes<'a>
+        = Vec<u8>
+    where
+        Self: 'a;
+
+    fn fixed_width() -> Option<usize> {
+        None
+    }
+
+    fn from_bytes<'a>(data: &'a [u8]) -> Self::SelfType<'a>
+    where
+        Self: 'a,
+    {
+        Self {
+            inner: serde_json::from_slice(data)
+                .expect("Failed to deserialize CachedValue from bytes."),
+        }
+    }
+
+    fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> Self::AsBytes<'a>
+    where
+        Self: 'b,
+    {
+        serde_json::to_vec(&value.inner).expect("Failed to serialize CachedValue into bytes.")
+    }
+
+    fn type_name() -> redb::TypeName {
+        redb::TypeName::new("[plugin-cargo] CachedValue")
+    }
+}
+
+/// Generate a new cached repo and its output regarding tests and package information.
+pub fn cache(user_repo: &str) -> Result<(CachedKey, CachedValue)> {
+    let repo = Repo::new(user_repo)?;
+    let output = repo.output()?;
+    std::fs::remove_dir_all(&repo.dir)?;
+    Ok((
+        CachedKey {
+            user: repo.user,
+            repo: repo.repo,
+            git_info: repo.git_info,
+        },
+        CachedValue { inner: output },
+    ))
+}
+
+#[test]
+fn test_os_checker_test_suite() -> crate::Result<()> {
+    const FILE: &str = "cache-plugin-cargo-v-test.redb";
+
+    let (key, val) = cache("os-checker/os-checker-test-suite")?;
+
+    let db = Database::create(FILE)?;
+
+    let write_txn = db.begin_write()?;
+    {
+        let mut table = write_txn.open_table(TABLE)?;
+        table.insert(&key, &val)?;
+    }
+    write_txn.commit()?;
+
+    let read_txn = db.begin_read()?;
+    let table = read_txn.open_table(TABLE)?;
+    assert_eq!(val.json(), table.get(&key)?.unwrap().value().json());
+
+    Ok(())
+}

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -23,6 +23,15 @@ fn err_json(user: &str, repo: &str, err: &dyn std::error::Error) -> serde_json::
     })
 }
 
+#[test]
+fn test_strip_color() {
+    if let Err(err) = Repo::new("shilei-massclouds/arch_boot") {
+        println!("raw msg=\n{err:?}");
+        let msg = strip_ansi_escapes::strip_str(format!("{err:?}"));
+        println!("\n{msg}");
+    }
+}
+
 /// Generate a new cached repo and its output regarding tests and package information.
 fn gen_cache(user_repo: &str) -> Result<(CachedKey, CachedValue)> {
     let repo = Repo::new(user_repo)?;

--- a/src/cache/types.rs
+++ b/src/cache/types.rs
@@ -1,0 +1,117 @@
+use os_checker_plugin_cargo::repo::GitInfo;
+use plugin::prelude::serde_json;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CachedKey {
+    pub user: String,
+    pub repo: String,
+    pub api: Api,
+}
+
+impl redb::Key for CachedKey {
+    fn compare(data1: &[u8], data2: &[u8]) -> std::cmp::Ordering {
+        data1.cmp(data2)
+    }
+}
+
+impl redb::Value for CachedKey {
+    type SelfType<'a>
+        = CachedKey
+    where
+        Self: 'a;
+
+    type AsBytes<'a>
+        = Vec<u8>
+    where
+        Self: 'a;
+
+    fn fixed_width() -> Option<usize> {
+        None
+    }
+
+    fn from_bytes<'a>(data: &'a [u8]) -> Self::SelfType<'a>
+    where
+        Self: 'a,
+    {
+        serde_json::from_slice(data).expect("Failed to deserialize CachedKey from bytes.")
+    }
+
+    fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> Self::AsBytes<'a>
+    where
+        Self: 'b,
+    {
+        serde_json::to_vec(value).expect("Failed to serialize CachedKey into bytes.")
+    }
+
+    fn type_name() -> redb::TypeName {
+        redb::TypeName::new("[plugin-cargo] CachedKey")
+    }
+}
+
+#[derive(Debug)]
+pub struct CachedValue {
+    inner: serde_json::Value,
+}
+
+impl CachedValue {
+    pub fn new(inner: serde_json::Value) -> Self {
+        Self { inner }
+    }
+
+    pub fn json(&self) -> &serde_json::Value {
+        &self.inner
+    }
+}
+
+impl redb::Value for CachedValue {
+    type SelfType<'a>
+        = Self
+    where
+        Self: 'a;
+
+    type AsBytes<'a>
+        = Vec<u8>
+    where
+        Self: 'a;
+
+    fn fixed_width() -> Option<usize> {
+        None
+    }
+
+    fn from_bytes<'a>(data: &'a [u8]) -> Self::SelfType<'a>
+    where
+        Self: 'a,
+    {
+        Self {
+            inner: serde_json::from_slice(data)
+                .expect("Failed to deserialize CachedValue from bytes."),
+        }
+    }
+
+    fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> Self::AsBytes<'a>
+    where
+        Self: 'b,
+    {
+        serde_json::to_vec(&value.inner).expect("Failed to serialize CachedValue into bytes.")
+    }
+
+    fn type_name() -> redb::TypeName {
+        redb::TypeName::new("[plugin-cargo] CachedValue")
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Api {
+    branch: String,
+    sha: String,
+}
+
+impl From<GitInfo> for Api {
+    fn from(info: GitInfo) -> Self {
+        Api {
+            branch: info.branch,
+            sha: info.sha,
+        }
+    }
+}

--- a/src/cache/types.rs
+++ b/src/cache/types.rs
@@ -59,8 +59,8 @@ impl CachedValue {
         Self { inner }
     }
 
-    pub fn json(&self) -> &serde_json::Value {
-        &self.inner
+    pub fn into_json(self) -> serde_json::Value {
+        self.inner
     }
 }
 

--- a/src/cache/types.rs
+++ b/src/cache/types.rs
@@ -62,6 +62,28 @@ impl CachedValue {
     pub fn into_json(self) -> serde_json::Value {
         self.inner
     }
+
+    // update end timestamp
+    pub fn update_timestamp(&mut self) {
+        const TIMESTAMP: &str = "timestamp";
+        const START: &str = "start";
+        const END: &str = "end";
+
+        let now = os_checker_types::now();
+
+        if let Some(ts) = self.inner.get_mut(TIMESTAMP) {
+            if let Some(end) = ts.get_mut(END) {
+                *end = serde_json::json!(now);
+            }
+        } else if let Some(map) = self.inner.as_object_mut() {
+            map.insert(
+                TIMESTAMP.to_owned(),
+                serde_json::json!({
+                    START: now, END: now
+                }),
+            );
+        }
+    }
 }
 
 impl redb::Value for CachedValue {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,8 @@ use plugin::{logger, prelude::*, repos, write_json};
 #[macro_use]
 extern crate tracing;
 
+mod cache;
+
 fn main() -> Result<()> {
     logger::init();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use os_checker_plugin_cargo::BASE_DIR;
+use os_checker_plugin_cargo::{repo::write_output_json, BASE_DIR};
 use plugin::{logger, prelude::*, repos, write_json};
 
 #[macro_use]
@@ -15,7 +15,11 @@ fn main() -> Result<()> {
     for user_repo in &list {
         let _span = error_span!("list", user_repo).entered();
         match cache::get_or_gen_cache(user_repo) {
-            Ok((_, val)) => outputs.push(val.into_json()),
+            Ok((key, val)) => {
+                let json = val.into_json();
+                write_output_json(&key.user, &key.repo, &json)?;
+                outputs.push(json);
+            }
             Err(err) => error!(?err),
         };
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use os_checker_plugin_cargo::{repo, BASE_DIR};
+use os_checker_plugin_cargo::BASE_DIR;
 use plugin::{logger, prelude::*, repos, write_json};
 
 #[macro_use]
@@ -14,16 +14,8 @@ fn main() -> Result<()> {
 
     for user_repo in &list {
         let _span = error_span!("list", user_repo).entered();
-        match repo::Repo::new(user_repo) {
-            Ok(repo) => {
-                match repo.output() {
-                    Ok(output) => outputs.push(output),
-                    Err(err) => error!(?err),
-                }
-                if let Err(err) = repo.remove_local_dir() {
-                    error!(?err);
-                };
-            }
+        match cache::get_or_gen_cache(user_repo) {
+            Ok((_, val)) => outputs.push(val.into_json()),
             Err(err) => error!(?err),
         };
     }

--- a/src/repo/git_info.rs
+++ b/src/repo/git_info.rs
@@ -1,7 +1,7 @@
 use plugin::prelude::{cmd, duct, Result, Timestamp, Utf8Path};
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GitInfo {
     pub last_commit: Timestamp,
     pub sha: String,

--- a/src/repo/git_info.rs
+++ b/src/repo/git_info.rs
@@ -1,0 +1,50 @@
+use plugin::prelude::{cmd, duct, Result, Timestamp, Utf8Path};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GitInfo {
+    pub last_commit: Timestamp,
+    pub sha: String,
+    pub branch: String,
+}
+
+impl GitInfo {
+    pub fn new(root: &Utf8Path) -> Result<Self> {
+        let last_commit = last_commit_time(root)?;
+        let sha = head_sha(root)?;
+        let branch = current_branch(root)?;
+        Ok(Self {
+            last_commit,
+            sha,
+            branch,
+        })
+    }
+}
+
+fn run(expr: duct::Expression, root: &Utf8Path) -> Result<String> {
+    Ok(expr.dir(root).read()?.trim().to_owned())
+}
+
+fn last_commit_time(root: &Utf8Path) -> Result<Timestamp> {
+    let cmd = cmd!("git", "log", "-1", "--pretty=format:%ct");
+    // git log -1 --format="%ct"
+    let unix_timestamp = run(cmd, root)?.parse()?;
+    Ok(Timestamp::from_second(unix_timestamp)?)
+}
+
+fn head_sha(root: &Utf8Path) -> Result<String> {
+    // git rev-parse HEAD
+    run(cmd!("git", "rev-parse", "HEAD"), root)
+}
+
+fn current_branch(root: &Utf8Path) -> Result<String> {
+    // git branch --show-current
+    run(cmd!("git", "branch", "--show-current"), root)
+}
+
+#[test]
+fn git_info() -> Result<()> {
+    let root = ".".into();
+    dbg!(GitInfo::new(root)?);
+    Ok(())
+}

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -14,7 +14,7 @@ mod os_checker;
 mod output;
 mod testcases;
 
-pub fn split_user_repo(user_repo: &str) -> Result<[&str; 2]> {
+pub fn split_user_repo(user_repo: &str) -> Result<[String; 2]> {
     let mut split = user_repo.split("/");
     let user = split
         .next()
@@ -22,7 +22,7 @@ pub fn split_user_repo(user_repo: &str) -> Result<[&str; 2]> {
     let repo = split
         .next()
         .with_context(|| format!("Not found repo in `{user_repo}`."))?;
-    Ok([user, repo])
+    Ok([user.to_owned(), repo.to_owned()])
 }
 
 #[derive(Debug)]
@@ -44,7 +44,7 @@ impl Repo {
         // this implies repo downloading
         let pkg_targets = os_checker::run(user_repo)?;
 
-        let dir = local_repo_dir(user, repo);
+        let dir = local_repo_dir(&user, &repo);
         let mut cargo_tomls = get_cargo_tomls_recursively(&dir);
         cargo_tomls.sort_unstable();
 
@@ -53,8 +53,8 @@ impl Repo {
         let git_info = GitInfo::new(&dir)?;
 
         Ok(Repo {
-            user: user.to_owned(),
-            repo: repo.to_owned(),
+            user,
+            repo,
             dir,
             pkg_targets,
             cargo_tomls,

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -213,12 +213,7 @@ fn workspaces(cargo_tomls: &[Utf8PathBuf]) -> Result<Workspaces> {
         let metadata = cargo_metadata::MetadataCommand::new()
             .manifest_path(cargo_toml)
             .exec()
-            .map_err(|err| {
-                eyre!(
-                    "无法读取 cargo metadata 的结果：\n{}",
-                    strip_ansi_escapes::strip_str(format!("{err}"))
-                )
-            })?;
+            .with_context(|| format!("无法读取 {cargo_toml} 内 cargo metadata 的结果"))?;
         let root = &metadata.workspace_root;
         // 每个 member package 解析的 workspace_root 和 members 是一样的
         if !map.contains_key(root) {

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -152,21 +152,20 @@ impl Repo {
             },
             "pkgs": outputs
         });
-        self.write_json(&json)?;
 
         Ok(json)
-    }
-
-    fn write_json(&self, json: &serde_json::Value) -> Result<()> {
-        let mut path = Utf8PathBuf::from_iter([crate::BASE_DIR, &self.user, &self.repo]);
-        path.set_extension("json");
-        write_json(&path, json)
     }
 
     pub fn remove_local_dir(self) -> Result<()> {
         std::fs::remove_dir_all(&self.dir)?;
         Ok(())
     }
+}
+
+pub fn write_output_json(user: &str, repo: &str, json: &serde_json::Value) -> Result<()> {
+    let mut path = Utf8PathBuf::from_iter([crate::BASE_DIR, user, repo]);
+    path.set_extension("json");
+    write_json(&path, json)
 }
 
 pub fn local_base_dir() -> &'static Utf8Path {

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -213,7 +213,12 @@ fn workspaces(cargo_tomls: &[Utf8PathBuf]) -> Result<Workspaces> {
         let metadata = cargo_metadata::MetadataCommand::new()
             .manifest_path(cargo_toml)
             .exec()
-            .map_err(|err| eyre!("无法读取 cargo metadata 的结果：{err}"))?;
+            .map_err(|err| {
+                eyre!(
+                    "无法读取 cargo metadata 的结果：\n{}",
+                    strip_ansi_escapes::strip_str(format!("{err:?}"))
+                )
+            })?;
         let root = &metadata.workspace_root;
         // 每个 member package 解析的 workspace_root 和 members 是一样的
         if !map.contains_key(root) {

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -1,13 +1,14 @@
 use crate::{crates_io::IndexFile, database::diag_total_count};
 use cargo_metadata::Package;
 use eyre::ContextCompat;
-use git_info::GitInfo;
 use output::Output;
 use plugin::{prelude::*, write_json};
 use std::sync::LazyLock;
 use testcases::PkgTests;
 
 mod git_info;
+pub use git_info::GitInfo;
+
 mod miri;
 mod os_checker;
 mod output;
@@ -158,10 +159,6 @@ impl Repo {
         std::fs::remove_dir_all(&self.dir)?;
         Ok(())
     }
-
-    // pub fn git_info(&self) ->  {
-    //
-    // }
 }
 
 pub fn local_base_dir() -> &'static Utf8Path {

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -213,7 +213,12 @@ fn workspaces(cargo_tomls: &[Utf8PathBuf]) -> Result<Workspaces> {
         let metadata = cargo_metadata::MetadataCommand::new()
             .manifest_path(cargo_toml)
             .exec()
-            .with_context(|| format!("无法读取 {cargo_toml} 内 cargo metadata 的结果"))?;
+            .map_err(|err| {
+                eyre!(
+                    "无法读取 cargo metadata 的结果：\n{}",
+                    strip_ansi_escapes::strip_str(format!("{err}"))
+                )
+            })?;
         let root = &metadata.workspace_root;
         // 每个 member package 解析的 workspace_root 和 members 是一样的
         if !map.contains_key(root) {

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -216,7 +216,7 @@ fn workspaces(cargo_tomls: &[Utf8PathBuf]) -> Result<Workspaces> {
             .map_err(|err| {
                 eyre!(
                     "无法读取 cargo metadata 的结果：\n{}",
-                    strip_ansi_escapes::strip_str(format!("{err}"))
+                    strip_ansi_escapes::strip_str(format!("{err:?}"))
                 )
             })?;
         let root = &metadata.workspace_root;

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -142,9 +142,14 @@ impl Repo {
 
         outputs.sort_unstable_keys();
 
+        let now = os_checker_types::now();
         let json = serde_json::json!({
             "user": self.user,
             "repo": self.repo,
+            "timestamp": {
+                "start": now,
+                "end": now
+            },
             "pkgs": outputs
         });
         self.write_json(&json)?;

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -216,7 +216,7 @@ fn workspaces(cargo_tomls: &[Utf8PathBuf]) -> Result<Workspaces> {
             .map_err(|err| {
                 eyre!(
                     "无法读取 cargo metadata 的结果：\n{}",
-                    strip_ansi_escapes::strip_str(format!("{err:?}"))
+                    strip_ansi_escapes::strip_str(format!("{err}"))
                 )
             })?;
         let root = &metadata.workspace_root;


### PR DESCRIPTION
[cache-plugin-cargo-v0.1.4.redb](https://github.com/os-checker/database/releases/tag/cache-plugin-cargo-v0.1.4.redb)

close #27 
close #28

Add start & end of timestamp object.

And store err msg and generate the json like this: pkgs field is not present to indicate the repo is errorous

```json
{
  "user": "sysones",
  "repo": "rcore-tutorial-v3-with-hal-component",
  "timestamp": {
    "start": 1740851742057,
    "end": 1740881454914
  },
  "err": "\n   0: 无法读取 cargo metadata 的结果：\n      `cargo metadata` exited with an error:     Updating crates.io index\n          Updating git repository `https://github.com/Byte-OS/polyhal.git`\n          Updating git repository `https://github.com/rcore-os/virtio-drivers`\n      error: failed to select a version for `polyhal`.\n          ... required by package `os v0.1.0 (/tmp/os-checker-plugin-cargo/sysones/rcore-tutorial-v3-with-hal-component/os)`\n      versions that meet the requirements `*` are: 0.1.3\n\n      the package `os` depends on `polyhal`, with features: `kcontext` but `polyhal` does not have these features.\n\n\n      failed to select a version for `polyhal` which could resolve this conflict\n   0: \n\nLocation:\n   src/repo/mod.rs:217\n\n  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ SPANTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n   0: os_checker_plugin_cargo::cache::cache with key=\"Api { branch: \\\"ch7\\\", sha: \\\"794bb3a264a07abbf727fbb3969c37600906d578\\\" }\"\n      at src/cache/mod.rs:60\n   1: os_checker_plugin_cargo::list with user_repo=\"sysones/rcore-tutorial-v3-with-hal-component\"\n      at src/main.rs:16\n\nBacktrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.\nRun with RUST_BACKTRACE=full to include source snippets."
}
```